### PR TITLE
test: agregar tests y documentacion swagger

### DIFF
--- a/src/change-windows/change-windows.controller.ts
+++ b/src/change-windows/change-windows.controller.ts
@@ -7,30 +7,78 @@ import {
   Param,
   Delete,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 import { ChangeWindowsService } from './services/change-windows.service';
 import { CreateChangeWindowDto } from './dto/create-change-window.dto';
 import { UpdateChangeWindowDto } from './dto/update-change-window.dto';
 
+@ApiTags('Change Windows')
 @Controller('change-windows')
 export class ChangeWindowsController {
   constructor(private readonly changeWindowsService: ChangeWindowsService) {}
 
   @Post()
+  @ApiOperation({
+    summary: 'Create a new change window',
+    description: 'Creates a new change window period for course modifications',
+  })
+  @ApiBody({ type: CreateChangeWindowDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Change window successfully created',
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
   create(@Body() createChangeWindowDto: CreateChangeWindowDto) {
     return this.changeWindowsService.create(createChangeWindowDto);
   }
 
   @Get()
+  @ApiOperation({
+    summary: 'Get all change windows',
+    description: 'Retrieves a list of all change windows in the system',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of change windows retrieved successfully',
+  })
   findAll() {
     return this.changeWindowsService.findAll();
   }
 
   @Get(':id')
+  @ApiOperation({
+    summary: 'Get change window by ID',
+    description: 'Retrieves a specific change window by its ID',
+  })
+  @ApiParam({ name: 'id', description: 'Change window ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Change window found',
+  })
+  @ApiResponse({ status: 404, description: 'Change window not found' })
   findOne(@Param('id') id: string) {
     return this.changeWindowsService.findOne(+id);
   }
 
   @Patch(':id')
+  @ApiOperation({
+    summary: 'Update change window',
+    description: 'Updates an existing change window by ID',
+  })
+  @ApiParam({ name: 'id', description: 'Change window ID' })
+  @ApiBody({ type: UpdateChangeWindowDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Change window successfully updated',
+  })
+  @ApiResponse({ status: 404, description: 'Change window not found' })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
   update(
     @Param('id') id: string,
     @Body() updateChangeWindowDto: UpdateChangeWindowDto,
@@ -39,6 +87,16 @@ export class ChangeWindowsController {
   }
 
   @Delete(':id')
+  @ApiOperation({
+    summary: 'Delete change window',
+    description: 'Removes a change window from the system',
+  })
+  @ApiParam({ name: 'id', description: 'Change window ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Change window successfully deleted',
+  })
+  @ApiResponse({ status: 404, description: 'Change window not found' })
   remove(@Param('id') id: string) {
     return this.changeWindowsService.remove(+id);
   }

--- a/src/enrollments/enrollments.controller.ts
+++ b/src/enrollments/enrollments.controller.ts
@@ -7,20 +7,51 @@ import {
   Param,
   Delete,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 import { EnrollmentsService } from './services/enrollments.service';
 import { CreateEnrollmentDto } from './dto/create-enrollment.dto';
 import { UpdateEnrollmentDto } from './dto/update-enrollment.dto';
 
+@ApiTags('Enrollments')
 @Controller('enrollments')
 export class EnrollmentsController {
   constructor(private readonly enrollmentsService: EnrollmentsService) {}
 
   @Post()
+  @ApiOperation({
+    summary: 'Create a new enrollment',
+    description: 'Creates a new enrollment record for a student in a course',
+  })
+  @ApiBody({ type: CreateEnrollmentDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Enrollment successfully created',
+  })
+  @ApiResponse({ status: 400, description: 'Invalid enrollment data' })
+  @ApiResponse({ status: 409, description: 'Enrollment already exists' })
   create(@Body() createEnrollmentDto: CreateEnrollmentDto) {
     return this.enrollmentsService.create(createEnrollmentDto);
   }
 
   @Post(':studentCode/enroll/:groupId')
+  @ApiOperation({
+    summary: 'Enroll student in course group',
+    description: 'Enrolls a student in a specific course group',
+  })
+  @ApiParam({ name: 'studentCode', description: 'Student code' })
+  @ApiParam({ name: 'groupId', description: 'Course group ID' })
+  @ApiResponse({
+    status: 201,
+    description: 'Student successfully enrolled in the course group',
+  })
+  @ApiResponse({ status: 404, description: 'Student or group not found' })
+  @ApiResponse({ status: 409, description: 'Student already enrolled' })
   enrollStudent(
     @Param('studentCode') studentCode: string,
     @Param('groupId') groupId: string,
@@ -29,21 +60,61 @@ export class EnrollmentsController {
   }
 
   @Get()
+  @ApiOperation({
+    summary: 'Get all enrollments',
+    description: 'Retrieves a list of all enrollments in the system',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of enrollments retrieved successfully',
+  })
   findAll() {
     return this.enrollmentsService.findAll();
   }
 
   @Get('student/:studentCode')
+  @ApiOperation({
+    summary: 'Get enrollments by student',
+    description: 'Retrieves all enrollments for a specific student',
+  })
+  @ApiParam({ name: 'studentCode', description: 'Student code' })
+  @ApiResponse({
+    status: 200,
+    description: 'Student enrollments retrieved successfully',
+  })
+  @ApiResponse({ status: 404, description: 'Student not found' })
   findByStudent(@Param('studentCode') studentCode: string) {
     return this.enrollmentsService.findByStudent(studentCode);
   }
 
   @Get(':id')
+  @ApiOperation({
+    summary: 'Get enrollment by ID',
+    description: 'Retrieves a specific enrollment by its ID',
+  })
+  @ApiParam({ name: 'id', description: 'Enrollment ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Enrollment found',
+  })
+  @ApiResponse({ status: 404, description: 'Enrollment not found' })
   findOne(@Param('id') id: string) {
     return this.enrollmentsService.findOne(id);
   }
 
   @Patch(':id')
+  @ApiOperation({
+    summary: 'Update enrollment',
+    description: 'Updates an existing enrollment by ID',
+  })
+  @ApiParam({ name: 'id', description: 'Enrollment ID' })
+  @ApiBody({ type: UpdateEnrollmentDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Enrollment successfully updated',
+  })
+  @ApiResponse({ status: 404, description: 'Enrollment not found' })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
   update(
     @Param('id') id: string,
     @Body() updateEnrollmentDto: UpdateEnrollmentDto,
@@ -52,6 +123,16 @@ export class EnrollmentsController {
   }
 
   @Delete(':id')
+  @ApiOperation({
+    summary: 'Delete enrollment',
+    description: 'Removes an enrollment from the system',
+  })
+  @ApiParam({ name: 'id', description: 'Enrollment ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Enrollment successfully deleted',
+  })
+  @ApiResponse({ status: 404, description: 'Enrollment not found' })
   remove(@Param('id') id: string) {
     return this.enrollmentsService.remove(id);
   }

--- a/src/group-schedules/group-schedules.controller.ts
+++ b/src/group-schedules/group-schedules.controller.ts
@@ -7,30 +7,80 @@ import {
   Param,
   Delete,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 import { GroupSchedulesService } from './services/group-schedules.service';
 import { CreateGroupScheduleDto } from './dto/create-group-schedule.dto';
 import { UpdateGroupScheduleDto } from './dto/update-group-schedule.dto';
 
+@ApiTags('Group Schedules')
 @Controller('group-schedules')
 export class GroupSchedulesController {
   constructor(private readonly groupSchedulesService: GroupSchedulesService) {}
 
   @Post()
+  @ApiOperation({
+    summary: 'Create a new group schedule',
+    description: 'Creates a new schedule entry for a course group',
+  })
+  @ApiBody({ type: CreateGroupScheduleDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Group schedule successfully created',
+  })
+  @ApiResponse({ status: 400, description: 'Invalid schedule data' })
+  @ApiResponse({ status: 409, description: 'Schedule conflict detected' })
   create(@Body() createGroupScheduleDto: CreateGroupScheduleDto) {
     return this.groupSchedulesService.create(createGroupScheduleDto);
   }
 
   @Get()
+  @ApiOperation({
+    summary: 'Get all group schedules',
+    description: 'Retrieves a list of all group schedules in the system',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of group schedules retrieved successfully',
+  })
   findAll() {
     return this.groupSchedulesService.findAll();
   }
 
   @Get(':id')
+  @ApiOperation({
+    summary: 'Get group schedule by ID',
+    description: 'Retrieves a specific group schedule by its ID',
+  })
+  @ApiParam({ name: 'id', description: 'Group schedule ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Group schedule found',
+  })
+  @ApiResponse({ status: 404, description: 'Group schedule not found' })
   findOne(@Param('id') id: string) {
     return this.groupSchedulesService.findOne(+id);
   }
 
   @Patch(':id')
+  @ApiOperation({
+    summary: 'Update group schedule',
+    description: 'Updates an existing group schedule by ID',
+  })
+  @ApiParam({ name: 'id', description: 'Group schedule ID' })
+  @ApiBody({ type: UpdateGroupScheduleDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Group schedule successfully updated',
+  })
+  @ApiResponse({ status: 404, description: 'Group schedule not found' })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 409, description: 'Schedule conflict detected' })
   update(
     @Param('id') id: string,
     @Body() updateGroupScheduleDto: UpdateGroupScheduleDto,
@@ -39,6 +89,16 @@ export class GroupSchedulesController {
   }
 
   @Delete(':id')
+  @ApiOperation({
+    summary: 'Delete group schedule',
+    description: 'Removes a group schedule from the system',
+  })
+  @ApiParam({ name: 'id', description: 'Group schedule ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Group schedule successfully deleted',
+  })
+  @ApiResponse({ status: 404, description: 'Group schedule not found' })
   remove(@Param('id') id: string) {
     return this.groupSchedulesService.remove(+id);
   }

--- a/src/programs/programs.controller.ts
+++ b/src/programs/programs.controller.ts
@@ -7,6 +7,13 @@ import {
   Param,
   Delete,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 import { ProgramsService } from './services/programs.service';
 import { CreateProgramDto } from './dto/create-program.dto';
 import { UpdateProgramDto } from './dto/update-program.dto';
@@ -16,10 +23,10 @@ import { UpdateProgramDto } from './dto/update-program.dto';
  *
  * ! Controller sin implementar - Servicio retorna solo strings placeholder
  * ? Maneja programas academicos (carreras) asociados a facultades
- * TODO: Implementar Swagger documentation completa
- * TODO: Validar permisos ADMIN/DEAN para creacion y modificacion
+ * TODO: Implementar validacion de permisos ADMIN/DEAN para creacion y modificacion
  * TODO: Agregar relacion con facultades y estudiantes
  */
+@ApiTags('Academic Programs')
 @Controller('programs')
 export class ProgramsController {
   constructor(private readonly programsService: ProgramsService) {}
@@ -31,6 +38,17 @@ export class ProgramsController {
    * TODO: Validar creditos totales y semestres del programa
    */
   @Post()
+  @ApiOperation({
+    summary: 'Create a new academic program',
+    description: 'Creates a new academic program (career) associated with a faculty',
+  })
+  @ApiBody({ type: CreateProgramDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Academic program successfully created',
+  })
+  @ApiResponse({ status: 400, description: 'Invalid program data' })
+  @ApiResponse({ status: 409, description: 'Program code already exists' })
   create(@Body() createProgramDto: CreateProgramDto) {
     return this.programsService.create(createProgramDto);
   }
@@ -42,6 +60,14 @@ export class ProgramsController {
    * TODO: Incluir estadisticas de estudiantes inscritos
    */
   @Get()
+  @ApiOperation({
+    summary: 'Get all academic programs',
+    description: 'Retrieves a list of all academic programs in the system',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of academic programs retrieved successfully',
+  })
   findAll() {
     return this.programsService.findAll();
   }
@@ -53,6 +79,16 @@ export class ProgramsController {
    * TODO: Mostrar estudiantes activos y estadisticas del programa
    */
   @Get(':id')
+  @ApiOperation({
+    summary: 'Get academic program by ID',
+    description: 'Retrieves a specific academic program with faculty and curriculum information',
+  })
+  @ApiParam({ name: 'id', description: 'Academic program ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Academic program found',
+  })
+  @ApiResponse({ status: 404, description: 'Academic program not found' })
   findOne(@Param('id') id: string) {
     return this.programsService.findOne(+id);
   }
@@ -64,6 +100,18 @@ export class ProgramsController {
    * TODO: Validar impacto en estudiantes antes de cambios criticos
    */
   @Patch(':id')
+  @ApiOperation({
+    summary: 'Update academic program',
+    description: 'Updates an existing academic program. Changes may affect enrolled students',
+  })
+  @ApiParam({ name: 'id', description: 'Academic program ID' })
+  @ApiBody({ type: UpdateProgramDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Academic program successfully updated',
+  })
+  @ApiResponse({ status: 404, description: 'Academic program not found' })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
   update(@Param('id') id: string, @Body() updateProgramDto: UpdateProgramDto) {
     return this.programsService.update(+id, updateProgramDto);
   }
@@ -76,6 +124,20 @@ export class ProgramsController {
    * TODO: Ofrecer transferencia de estudiantes a otro programa
    */
   @Delete(':id')
+  @ApiOperation({
+    summary: 'Delete academic program',
+    description: 'Removes an academic program. Cannot delete programs with active students',
+  })
+  @ApiParam({ name: 'id', description: 'Academic program ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Academic program successfully deleted',
+  })
+  @ApiResponse({ status: 404, description: 'Academic program not found' })
+  @ApiResponse({
+    status: 409,
+    description: 'Cannot delete program with active students',
+  })
   remove(@Param('id') id: string) {
     return this.programsService.remove(+id);
   }

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -7,35 +7,93 @@ import {
   Param,
   Delete,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 import { ReportsService } from './services/reports.service';
 import { CreateReportDto } from './dto/create-report.dto';
 import { UpdateReportDto } from './dto/update-report.dto';
 
+@ApiTags('Reports')
 @Controller('reports')
 export class ReportsController {
   constructor(private readonly reportsService: ReportsService) {}
 
   @Post()
+  @ApiOperation({
+    summary: 'Generate a new report',
+    description: 'Creates a new report based on specified criteria and parameters',
+  })
+  @ApiBody({ type: CreateReportDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Report successfully generated',
+  })
+  @ApiResponse({ status: 400, description: 'Invalid report parameters' })
   create(@Body() createReportDto: CreateReportDto) {
     return this.reportsService.create(createReportDto);
   }
 
   @Get()
+  @ApiOperation({
+    summary: 'Get all reports',
+    description: 'Retrieves a list of all generated reports in the system',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of reports retrieved successfully',
+  })
   findAll() {
     return this.reportsService.findAll();
   }
 
   @Get(':id')
+  @ApiOperation({
+    summary: 'Get report by ID',
+    description: 'Retrieves a specific report by its ID',
+  })
+  @ApiParam({ name: 'id', description: 'Report ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Report found',
+  })
+  @ApiResponse({ status: 404, description: 'Report not found' })
   findOne(@Param('id') id: string) {
     return this.reportsService.findOne(+id);
   }
 
   @Patch(':id')
+  @ApiOperation({
+    summary: 'Update report',
+    description: 'Updates an existing report configuration or parameters',
+  })
+  @ApiParam({ name: 'id', description: 'Report ID' })
+  @ApiBody({ type: UpdateReportDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Report successfully updated',
+  })
+  @ApiResponse({ status: 404, description: 'Report not found' })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
   update(@Param('id') id: string, @Body() updateReportDto: UpdateReportDto) {
     return this.reportsService.update(+id, updateReportDto);
   }
 
   @Delete(':id')
+  @ApiOperation({
+    summary: 'Delete report',
+    description: 'Removes a report from the system',
+  })
+  @ApiParam({ name: 'id', description: 'Report ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Report successfully deleted',
+  })
+  @ApiResponse({ status: 404, description: 'Report not found' })
   remove(@Param('id') id: string) {
     return this.reportsService.remove(+id);
   }

--- a/src/roles/roles.controller.ts
+++ b/src/roles/roles.controller.ts
@@ -7,6 +7,14 @@ import {
   Param,
   Delete,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { RolesService } from './services/roles.service';
 
 /**
@@ -17,9 +25,10 @@ import { RolesService } from './services/roles.service';
  * TODO: Implementar CRUD completo para roles
  * TODO: Agregar endpoints para gestion de permisos
  * TODO: Implementar validacion de ADMIN-only para estas operaciones
- * TODO: Agregar Swagger documentation
  */
+@ApiTags('Roles & Permissions')
 @Controller('roles')
+@ApiBearerAuth()
 export class RolesController {
   constructor(private readonly rolesService: RolesService) {}
 
@@ -32,4 +41,105 @@ export class RolesController {
   // TODO: @Get(':id/permissions') getRolePermissions() - Obtener permisos de rol
   // TODO: @Post(':id/permissions') addPermissions() - Agregar permisos a rol
   // TODO: @Delete(':id/permissions/:permission') removePermission() - Quitar permiso
+
+  /**
+   * Placeholder endpoints for future implementation
+   * These endpoints are documented but not yet implemented
+   */
+
+  // @Get()
+  // @ApiOperation({
+  //   summary: 'Get all roles',
+  //   description: 'Retrieves a list of all roles in the system',
+  // })
+  // @ApiResponse({ status: 200, description: 'List of roles retrieved successfully' })
+  // findAll() {
+  //   return this.rolesService.findAll();
+  // }
+
+  // @Get(':id')
+  // @ApiOperation({
+  //   summary: 'Get role by ID',
+  //   description: 'Retrieves a specific role by its ID',
+  // })
+  // @ApiParam({ name: 'id', description: 'Role ID' })
+  // @ApiResponse({ status: 200, description: 'Role found' })
+  // @ApiResponse({ status: 404, description: 'Role not found' })
+  // findOne(@Param('id') id: string) {
+  //   return this.rolesService.findOne(+id);
+  // }
+
+  // @Post()
+  // @ApiOperation({
+  //   summary: 'Create a new role',
+  //   description: 'Creates a new role with specified permissions',
+  // })
+  // @ApiResponse({ status: 201, description: 'Role successfully created' })
+  // @ApiResponse({ status: 400, description: 'Invalid role data' })
+  // @ApiResponse({ status: 409, description: 'Role already exists' })
+  // create(@Body() createRoleDto: any) {
+  //   return this.rolesService.create(createRoleDto);
+  // }
+
+  // @Patch(':id')
+  // @ApiOperation({
+  //   summary: 'Update role',
+  //   description: 'Updates an existing role',
+  // })
+  // @ApiParam({ name: 'id', description: 'Role ID' })
+  // @ApiResponse({ status: 200, description: 'Role successfully updated' })
+  // @ApiResponse({ status: 404, description: 'Role not found' })
+  // update(@Param('id') id: string, @Body() updateRoleDto: any) {
+  //   return this.rolesService.update(+id, updateRoleDto);
+  // }
+
+  // @Delete(':id')
+  // @ApiOperation({
+  //   summary: 'Delete role',
+  //   description: 'Removes a role from the system',
+  // })
+  // @ApiParam({ name: 'id', description: 'Role ID' })
+  // @ApiResponse({ status: 200, description: 'Role successfully deleted' })
+  // @ApiResponse({ status: 404, description: 'Role not found' })
+  // @ApiResponse({ status: 409, description: 'Cannot delete role in use' })
+  // remove(@Param('id') id: string) {
+  //   return this.rolesService.remove(+id);
+  // }
+
+  // @Get(':id/permissions')
+  // @ApiOperation({
+  //   summary: 'Get role permissions',
+  //   description: 'Retrieves all permissions assigned to a specific role',
+  // })
+  // @ApiParam({ name: 'id', description: 'Role ID' })
+  // @ApiResponse({ status: 200, description: 'Role permissions retrieved' })
+  // @ApiResponse({ status: 404, description: 'Role not found' })
+  // getRolePermissions(@Param('id') id: string) {
+  //   return this.rolesService.getRolePermissions(+id);
+  // }
+
+  // @Post(':id/permissions')
+  // @ApiOperation({
+  //   summary: 'Add permissions to role',
+  //   description: 'Assigns new permissions to an existing role',
+  // })
+  // @ApiParam({ name: 'id', description: 'Role ID' })
+  // @ApiResponse({ status: 200, description: 'Permissions added successfully' })
+  // @ApiResponse({ status: 404, description: 'Role not found' })
+  // addPermissions(@Param('id') id: string, @Body() permissions: any) {
+  //   return this.rolesService.addPermissions(+id, permissions);
+  // }
+
+  // @Delete(':id/permissions/:permission')
+  // @ApiOperation({
+  //   summary: 'Remove permission from role',
+  //   description: 'Removes a specific permission from a role',
+  // })
+  // @ApiParam({ name: 'id', description: 'Role ID' })
+  // @ApiParam({ name: 'permission', description: 'Permission identifier' })
+  // @ApiResponse({ status: 200, description: 'Permission removed successfully' })
+  // @ApiResponse({ status: 404, description: 'Role or permission not found' })
+  // removePermission(@Param('id') id: string, @Param('permission') permission: string) {
+  //   return this.rolesService.removePermission(+id, permission);
+  // }
 }

--- a/src/test/academic-periods.controller.spec.ts
+++ b/src/test/academic-periods.controller.spec.ts
@@ -69,7 +69,6 @@ describe('AcademicPeriodsController', () => {
         name: 'Primer Semestre 2025',
         startDate: new Date('2025-01-15'),
         endDate: new Date('2025-06-15'),
-        status: 'ACTIVE',
         isActive: false,
         allowChangeRequests: true,
         isEnrollmentOpen: true,
@@ -96,6 +95,78 @@ describe('AcademicPeriodsController', () => {
       const result = await controller.findAll();
 
       expect(service.findAll).toHaveBeenCalled();
+      expect(result).toEqual(periods);
+    });
+
+    it('should return empty array when no periods exist', async () => {
+      mockAcademicPeriodsService.findAll.mockResolvedValue([]);
+
+      const result = await controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('should return multiple periods', async () => {
+      const periods = [
+        mockPeriod,
+        { ...mockPeriod, _id: 'period456', code: '2025-1' },
+      ];
+      mockAcademicPeriodsService.findAll.mockResolvedValue(periods);
+
+      const result = await controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single period by ID', async () => {
+      mockAcademicPeriodsService.findOne.mockResolvedValue(mockPeriod);
+
+      const result = await controller.findOne('period123');
+
+      expect(service.findOne).toHaveBeenCalledWith('period123');
+      expect(result).toEqual(mockPeriod);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a period', async () => {
+      const updateDto: UpdateAcademicPeriodDto = {
+        name: 'Segundo Semestre 2024 Actualizado',
+      };
+      const updatedPeriod = { ...mockPeriod, ...updateDto };
+      mockAcademicPeriodsService.update.mockResolvedValue(updatedPeriod);
+
+      const result = await controller.update('period123', updateDto);
+
+      expect(service.update).toHaveBeenCalledWith('period123', updateDto);
+      expect(result).toEqual(updatedPeriod);
+    });
+  });
+
+  describe('getPeriodsAllowingChanges', () => {
+    it('should return periods that allow change requests', async () => {
+      const periods = [mockPeriod];
+      mockAcademicPeriodsService.getPeriodsAllowingChanges.mockResolvedValue(periods);
+
+      const result = await controller.getPeriodsAllowingChanges();
+
+      expect(service.getPeriodsAllowingChanges).toHaveBeenCalled();
+      expect(result).toEqual(periods);
+    });
+  });
+
+  describe('getPeriodsWithOpenEnrollment', () => {
+    it('should return periods with open enrollment', async () => {
+      const periods = [mockPeriod];
+      mockAcademicPeriodsService.getPeriodsWithOpenEnrollment.mockResolvedValue(periods);
+
+      const result = await controller.getPeriodsWithOpenEnrollment();
+
+      expect(service.getPeriodsWithOpenEnrollment).toHaveBeenCalled();
       expect(result).toEqual(periods);
     });
   });

--- a/src/test/admin.controller.spec.ts
+++ b/src/test/admin.controller.spec.ts
@@ -1,0 +1,176 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminController } from '../admin/admin.controller';
+import { AdminService } from '../admin/services/admin.service';
+import { CreateAdminDto } from '../admin/dto/create-admin.dto';
+import { UpdateAdminDto } from '../admin/dto/update-admin.dto';
+
+describe('AdminController', () => {
+  let controller: AdminController;
+  let service: AdminService;
+
+  const mockAdminService = {
+    create: jest.fn().mockReturnValue('This action adds a new admin'),
+    findAll: jest.fn().mockReturnValue(['This action returns all admin']),
+    findOne: jest.fn().mockReturnValue('This action returns a #1 admin'),
+    update: jest.fn().mockReturnValue('This action updates a #1 admin'),
+    remove: jest.fn().mockReturnValue('This action removes a #1 admin'),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminController],
+      providers: [
+        {
+          provide: AdminService,
+          useValue: mockAdminService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AdminController>(AdminController);
+    service = module.get<AdminService>(AdminService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a new admin operation', () => {
+      const createDto: CreateAdminDto = {};
+      const result = controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledWith(createDto);
+      expect(result).toBe('This action adds a new admin');
+    });
+
+    it('should call service create method once', () => {
+      const createDto: CreateAdminDto = {};
+      controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all admin operations', () => {
+      const result = controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toEqual(['This action returns all admin']);
+    });
+
+    it('should call service findAll method once', () => {
+      controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single admin operation', () => {
+      const id = '1';
+      const result = controller.findOne(id);
+
+      expect(service.findOne).toHaveBeenCalledWith(1);
+      expect(result).toBe('This action returns a #1 admin');
+    });
+
+    it('should convert string id to number', () => {
+      const id = '42';
+      controller.findOne(id);
+
+      expect(service.findOne).toHaveBeenCalledWith(42);
+    });
+
+    it('should call service findOne method once', () => {
+      controller.findOne('1');
+
+      expect(service.findOne).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('update', () => {
+    it('should update an admin operation', () => {
+      const id = '1';
+      const updateDto: UpdateAdminDto = {};
+      const result = controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(1, updateDto);
+      expect(result).toBe('This action updates a #1 admin');
+    });
+
+    it('should convert string id to number', () => {
+      const id = '99';
+      const updateDto: UpdateAdminDto = {};
+      controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(99, updateDto);
+    });
+
+    it('should call service update method once', () => {
+      controller.update('1', {});
+
+      expect(service.update).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove an admin operation', () => {
+      const id = '1';
+      const result = controller.remove(id);
+
+      expect(service.remove).toHaveBeenCalledWith(1);
+      expect(result).toBe('This action removes a #1 admin');
+    });
+
+    it('should convert string id to number', () => {
+      const id = '123';
+      controller.remove(id);
+
+      expect(service.remove).toHaveBeenCalledWith(123);
+    });
+
+    it('should call service remove method once', () => {
+      controller.remove('1');
+
+      expect(service.remove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Integration: Complete admin operation lifecycle', () => {
+    it('should create, retrieve, update and delete admin operations', () => {
+      const createDto: CreateAdminDto = {};
+      
+      // Create
+      const created = controller.create(createDto);
+      expect(created).toBeDefined();
+      expect(service.create).toHaveBeenCalledWith(createDto);
+
+      // Find all
+      const all = controller.findAll();
+      expect(all).toBeDefined();
+      expect(service.findAll).toHaveBeenCalled();
+
+      // Find one
+      const one = controller.findOne('1');
+      expect(one).toBeDefined();
+      expect(service.findOne).toHaveBeenCalledWith(1);
+
+      // Update
+      const updateDto: UpdateAdminDto = {};
+      const updated = controller.update('1', updateDto);
+      expect(updated).toBeDefined();
+      expect(service.update).toHaveBeenCalledWith(1, updateDto);
+
+      // Remove
+      const removed = controller.remove('1');
+      expect(removed).toBeDefined();
+      expect(service.remove).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/src/test/app.service.spec.ts
+++ b/src/test/app.service.spec.ts
@@ -110,6 +110,15 @@ describe('AppService', () => {
       expect(result.server).toHaveProperty('startTime');
     });
 
+    it('should format uptime correctly for short durations', async () => {
+      const result: any = await service.getStatus();
+      
+      expect(result.server.uptime).toBeDefined();
+      expect(typeof result.server.uptime).toBe('string');
+      // Uptime should contain "seconds" for short durations
+      expect(result.server.uptime).toMatch(/seconds|minutes|hours|days/);
+    });
+
     it('should include database status', async () => {
       const result: any = await service.getStatus();
 

--- a/src/test/audit.interceptor.spec.ts
+++ b/src/test/audit.interceptor.spec.ts
@@ -1,0 +1,334 @@
+import { AuditInterceptor } from '../common/interceptors/audit.interceptor';
+import { AuditService } from '../common/services/audit.service';
+import { Reflector } from '@nestjs/core';
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { of } from 'rxjs';
+import { AUDIT_CREATE_KEY } from '../common/decorators/audit-create.decorator';
+
+describe('AuditInterceptor', () => {
+  let interceptor: AuditInterceptor;
+  let auditService: jest.Mocked<AuditService>;
+  let reflector: jest.Mocked<Reflector>;
+
+  beforeEach(() => {
+    auditService = {
+      logCreateEvent: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    reflector = {
+      get: jest.fn(),
+    } as any;
+
+    interceptor = new AuditInterceptor(auditService, reflector);
+  });
+
+  function createMockContext(requestData: any = {}): ExecutionContext {
+    const defaultRequest = {
+      user: { id: 'user123' },
+      body: { name: 'Test Entity' },
+      ip: '192.168.1.1',
+      headers: { 'user-agent': 'Mozilla/5.0' },
+      ...requestData,
+    };
+
+    return {
+      getHandler: jest.fn(),
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue(defaultRequest),
+      }),
+    } as any;
+  }
+
+  function createMockCallHandler(response: any): CallHandler {
+    return {
+      handle: jest.fn().mockReturnValue(of(response)),
+    } as any;
+  }
+
+  it('should be defined', () => {
+    expect(interceptor).toBeDefined();
+  });
+
+  it('should not log if no audit decorator is present', (done) => {
+    reflector.get.mockReturnValue(null);
+    const context = createMockContext();
+    const callHandler = createMockCallHandler({ id: '123' });
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(auditService.logCreateEvent).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should log create event when audit decorator is present and response has id', (done) => {
+    reflector.get.mockReturnValue('ChangeRequest');
+    const context = createMockContext();
+    const callHandler = createMockCallHandler({ id: 'entity123', name: 'Test' });
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(auditService.logCreateEvent).toHaveBeenCalledWith(
+        'entity123',
+        'user123',
+        {
+          entityType: 'ChangeRequest',
+          data: { name: 'Test Entity' },
+          response: {
+            id: 'entity123',
+            status: 'created',
+          },
+        },
+        '192.168.1.1',
+        'Mozilla/5.0',
+      );
+      done();
+    });
+  });
+
+  it('should handle MongoDB _id format', (done) => {
+    reflector.get.mockReturnValue('Student');
+    const context = createMockContext();
+    const callHandler = createMockCallHandler({
+      _id: { toString: () => 'mongo-id-123' },
+      name: 'Student',
+    });
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(auditService.logCreateEvent).toHaveBeenCalledWith(
+        'mongo-id-123',
+        'user123',
+        expect.objectContaining({
+          entityType: 'Student',
+          response: {
+            id: 'mongo-id-123',
+            status: 'created',
+          },
+        }),
+        '192.168.1.1',
+        'Mozilla/5.0',
+      );
+      done();
+    });
+  });
+
+  it('should use "anonymous" for user when no user is present', (done) => {
+    reflector.get.mockReturnValue('Document');
+    const context = createMockContext({
+      user: undefined,
+      body: { title: 'Doc' },
+      ip: '10.0.0.1',
+      headers: { 'user-agent': 'Chrome' },
+    });
+    const callHandler = createMockCallHandler({ id: 'doc123' });
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(auditService.logCreateEvent).toHaveBeenCalledWith(
+        'doc123',
+        'anonymous',
+        expect.any(Object),
+        '10.0.0.1',
+        'Chrome',
+      );
+      done();
+    });
+  });
+
+  it('should not log if response has no id or _id', (done) => {
+    reflector.get.mockReturnValue('Entity');
+    const context = createMockContext();
+    const callHandler = createMockCallHandler({ name: 'No ID' });
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(auditService.logCreateEvent).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should read decorator metadata using AUDIT_CREATE_KEY', (done) => {
+    reflector.get.mockReturnValue('TestEntity');
+    const context = createMockContext();
+    const callHandler = createMockCallHandler({ id: '456' });
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(reflector.get).toHaveBeenCalledWith(AUDIT_CREATE_KEY, context.getHandler());
+      done();
+    });
+  });
+
+  it('should include request body in audit data', (done) => {
+    reflector.get.mockReturnValue('Order');
+    const requestBody = { productId: 'prod-123', quantity: 5 };
+    const context = createMockContext({
+      user: { id: 'user456' },
+      body: requestBody,
+      ip: '172.16.0.1',
+      headers: { 'user-agent': 'Safari' },
+    });
+    const callHandler = createMockCallHandler({ id: 'order789' });
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(auditService.logCreateEvent).toHaveBeenCalledWith(
+        'order789',
+        'user456',
+        expect.objectContaining({
+          data: requestBody,
+        }),
+        expect.any(String),
+        expect.any(String),
+      );
+      done();
+    });
+  });
+
+  it('should capture IP address correctly', (done) => {
+    reflector.get.mockReturnValue('Session');
+    const testIp = '203.0.113.42';
+    const context = createMockContext({
+      user: { id: 'user999' },
+      body: {},
+      ip: testIp,
+      headers: { 'user-agent': 'Edge' },
+    });
+    const callHandler = createMockCallHandler({ id: 'session123' });
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(auditService.logCreateEvent).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.any(Object),
+        testIp,
+        expect.any(String),
+      );
+      done();
+    });
+  });
+
+  it('should capture user-agent header correctly', (done) => {
+    reflector.get.mockReturnValue('Comment');
+    const userAgent = 'CustomApp/1.0';
+    const context = createMockContext({
+      user: { id: 'user555' },
+      body: { text: 'Test comment' },
+      ip: '192.0.2.1',
+      headers: { 'user-agent': userAgent },
+    });
+    const callHandler = createMockCallHandler({ id: 'comment456' });
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(auditService.logCreateEvent).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.any(Object),
+        expect.any(String),
+        userAgent,
+      );
+      done();
+    });
+  });
+
+  it('should pass through observable when no decorator', (done) => {
+    reflector.get.mockReturnValue(null);
+    const testResponse = { data: 'test' };
+    const context = createMockContext();
+    const callHandler = createMockCallHandler(testResponse);
+
+    interceptor.intercept(context, callHandler).subscribe((result) => {
+      expect(result).toEqual(testResponse);
+      done();
+    });
+  });
+
+  it('should handle empty response object', (done) => {
+    reflector.get.mockReturnValue('Entity');
+    const context = createMockContext();
+    const callHandler = createMockCallHandler({});
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(auditService.logCreateEvent).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should handle null response', (done) => {
+    reflector.get.mockReturnValue('Entity');
+    const context = createMockContext();
+    const callHandler = createMockCallHandler(null);
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(auditService.logCreateEvent).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should handle undefined response', (done) => {
+    reflector.get.mockReturnValue('Entity');
+    const context = createMockContext();
+    const callHandler = createMockCallHandler(undefined);
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(auditService.logCreateEvent).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should prefer id over _id when both are present', (done) => {
+    reflector.get.mockReturnValue('Entity');
+    const context = createMockContext();
+    const callHandler = createMockCallHandler({
+      id: 'standard-id',
+      _id: { toString: () => 'mongo-id' },
+    });
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(auditService.logCreateEvent).toHaveBeenCalledWith(
+        'standard-id',
+        expect.any(String),
+        expect.any(Object),
+        expect.any(String),
+        expect.any(String),
+      );
+      done();
+    });
+  });
+
+  it('should include entity type in audit metadata', (done) => {
+    const entityType = 'CustomEntity';
+    reflector.get.mockReturnValue(entityType);
+    const context = createMockContext();
+    const callHandler = createMockCallHandler({ id: 'custom123' });
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(auditService.logCreateEvent).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({
+          entityType: entityType,
+        }),
+        expect.any(String),
+        expect.any(String),
+      );
+      done();
+    });
+  });
+
+  it('should include response metadata with status created', (done) => {
+    reflector.get.mockReturnValue('Report');
+    const context = createMockContext();
+    const callHandler = createMockCallHandler({ id: 'report999' });
+
+    interceptor.intercept(context, callHandler).subscribe(() => {
+      expect(auditService.logCreateEvent).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({
+          response: {
+            id: 'report999',
+            status: 'created',
+          },
+        }),
+        expect.any(String),
+        expect.any(String),
+      );
+      done();
+    });
+  });
+});

--- a/src/test/audit.service.spec.ts
+++ b/src/test/audit.service.spec.ts
@@ -1,0 +1,602 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { AuditService, AuditEventData } from '../common/services/audit.service';
+import { AuditRequest, AuditRequestDocument } from '../common/entities/audit-request.entity';
+
+describe('AuditService', () => {
+  let service: AuditService;
+  let auditModel: Model<AuditRequestDocument>;
+
+  const mockRequestId = '60d5ecb8b0a7c4b4b8b9b1a1';
+  const mockActorId = '60d5ecb8b0a7c4b4b8b9b1a2';
+  const mockProgramId = '60d5ecb8b0a7c4b4b8b9b1a3';
+  const mockRadicado = '2024-001';
+
+  const mockAuditEntry = {
+    _id: '60d5ecb8b0a7c4b4b8b9b1a4',
+    requestId: mockRequestId,
+    eventType: 'CREATE',
+    actorId: mockActorId,
+    timestamp: new Date(),
+    save: jest.fn().mockResolvedValue(this),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditService,
+        {
+          provide: getModelToken(AuditRequest.name),
+          useValue: {
+            find: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<AuditService>(AuditService);
+    auditModel = module.get<Model<AuditRequestDocument>>(
+      getModelToken(AuditRequest.name),
+    );
+  });
+
+  describe('logEvent', () => {
+    it('should log audit event successfully', async () => {
+      const eventData: AuditEventData = {
+        requestId: mockRequestId,
+        eventType: 'CREATE',
+        actorId: mockActorId,
+        requestDetails: { test: 'data' },
+      };
+
+      const mockSave = jest.fn().mockResolvedValue({
+        ...mockAuditEntry,
+        ...eventData,
+      });
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      const result = await service.logEvent(eventData);
+
+      expect(mockSave).toHaveBeenCalled();
+      expect(result.requestId).toBe(mockRequestId);
+      expect(result.eventType).toBe('CREATE');
+    });
+
+    it('should log critical events with warning', async () => {
+      const eventData: AuditEventData = {
+        requestId: mockRequestId,
+        eventType: 'DELETE',
+        actorId: mockActorId,
+      };
+
+      const mockSave = jest.fn().mockResolvedValue({
+        ...mockAuditEntry,
+        ...eventData,
+        eventType: 'DELETE',
+      });
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      const result = await service.logEvent(eventData);
+
+      expect(mockSave).toHaveBeenCalled();
+      expect(result.eventType).toBe('DELETE');
+    });
+
+    it('should include timestamp in audit entry', async () => {
+      const eventData: AuditEventData = {
+        requestId: mockRequestId,
+        eventType: 'UPDATE',
+        actorId: mockActorId,
+      };
+
+      let capturedData: any;
+      const mockSave = jest.fn().mockImplementation(function (this: any) {
+        capturedData = this;
+        return Promise.resolve({ ...this, _id: 'test-id' });
+      });
+
+      (auditModel as any) = jest.fn().mockImplementation((data: any) => ({
+        ...data,
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      await service.logEvent(eventData);
+
+      expect(capturedData).toHaveProperty('timestamp');
+      expect(capturedData.timestamp).toBeInstanceOf(Date);
+    });
+
+    it('should throw error when save fails', async () => {
+      const eventData: AuditEventData = {
+        requestId: mockRequestId,
+        eventType: 'CREATE',
+        actorId: mockActorId,
+      };
+
+      const mockSave = jest.fn().mockRejectedValue(new Error('Database error'));
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      await expect(service.logEvent(eventData)).rejects.toThrow('Database error');
+    });
+
+    it('should include optional fields when provided', async () => {
+      const eventData: AuditEventData = {
+        requestId: mockRequestId,
+        eventType: 'CREATE',
+        actorId: mockActorId,
+        ipAddress: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+        sourceData: { field1: 'value1' },
+        targetData: { field2: 'value2' },
+      };
+
+      let capturedData: any;
+      const mockSave = jest.fn().mockImplementation(function (this: any) {
+        capturedData = this;
+        return Promise.resolve({ ...this, _id: 'test-id' });
+      });
+
+      (auditModel as any) = jest.fn().mockImplementation((data: any) => ({
+        ...data,
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      await service.logEvent(eventData);
+
+      expect(capturedData.ipAddress).toBe('192.168.1.1');
+      expect(capturedData.userAgent).toBe('Mozilla/5.0');
+      expect(capturedData.sourceData).toEqual({ field1: 'value1' });
+      expect(capturedData.targetData).toEqual({ field2: 'value2' });
+    });
+  });
+
+  describe('logCreateEvent', () => {
+    it('should log CREATE event with all details', async () => {
+      const requestDetails = { field: 'value' };
+      const ipAddress = '192.168.1.1';
+      const userAgent = 'Mozilla/5.0';
+
+      const mockSave = jest.fn().mockResolvedValue({
+        _id: 'test-id',
+        requestId: mockRequestId,
+        eventType: 'CREATE',
+        actorId: mockActorId,
+        requestDetails,
+        ipAddress,
+        userAgent,
+      });
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      const result = await service.logCreateEvent(
+        mockRequestId,
+        mockActorId,
+        requestDetails,
+        ipAddress,
+        userAgent,
+      );
+
+      expect(result.eventType).toBe('CREATE');
+      expect(result.requestDetails).toEqual(requestDetails);
+    });
+
+    it('should work without optional parameters', async () => {
+      const requestDetails = { field: 'value' };
+
+      const mockSave = jest.fn().mockResolvedValue({
+        _id: 'test-id',
+        requestId: mockRequestId,
+        eventType: 'CREATE',
+        actorId: mockActorId,
+        requestDetails,
+      });
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      const result = await service.logCreateEvent(
+        mockRequestId,
+        mockActorId,
+        requestDetails,
+      );
+
+      expect(result.eventType).toBe('CREATE');
+    });
+
+    it('should throw error on failure', async () => {
+      const mockSave = jest.fn().mockRejectedValue(new Error('Save failed'));
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      await expect(
+        service.logCreateEvent(mockRequestId, mockActorId, {}),
+      ).rejects.toThrow('Save failed');
+    });
+  });
+
+  describe('logRadicateEvent', () => {
+    it('should log RADICATE event with radicado details', async () => {
+      const priority = 'HIGH';
+      const priorityCriteria = { reason: 'mandatory subject' };
+
+      const mockSave = jest.fn().mockResolvedValue({
+        _id: 'test-id',
+        requestId: mockRequestId,
+        eventType: 'RADICATE',
+        actorId: 'system',
+        requestDetails: {
+          entityType: 'radicado_assignment',
+          radicado: mockRadicado,
+          priority,
+          priorityCriteria,
+        },
+      });
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      const result = await service.logRadicateEvent(
+        mockRequestId,
+        mockRadicado,
+        priority,
+        priorityCriteria,
+      );
+
+      expect(result.eventType).toBe('RADICATE');
+      expect(result.actorId).toBe('system');
+      expect(result.requestDetails).toHaveProperty('radicado', mockRadicado);
+      expect(result.requestDetails).toHaveProperty('priority', priority);
+    });
+
+    it('should include timestamp in request details', async () => {
+      let capturedData: any;
+      const mockSave = jest.fn().mockImplementation(function (this: any) {
+        capturedData = this;
+        return Promise.resolve({ ...this, _id: 'test-id' });
+      });
+
+      (auditModel as any) = jest.fn().mockImplementation((data: any) => ({
+        ...data,
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      await service.logRadicateEvent(mockRequestId, mockRadicado, 'NORMAL', {});
+
+      expect(capturedData.requestDetails).toHaveProperty('timestamp');
+    });
+
+    it('should throw error on failure', async () => {
+      const mockSave = jest.fn().mockRejectedValue(new Error('Database error'));
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      await expect(
+        service.logRadicateEvent(mockRequestId, mockRadicado, 'NORMAL', {}),
+      ).rejects.toThrow('Database error');
+    });
+  });
+
+  describe('logRouteEvent', () => {
+    it('should log ROUTE event with routing decision', async () => {
+      const routingDecision = { rule: 'SAME_PROGRAM', reason: 'test' };
+
+      const mockSave = jest.fn().mockResolvedValue({
+        _id: 'test-id',
+        requestId: mockRequestId,
+        eventType: 'ROUTE',
+        actorId: 'system',
+        requestDetails: {
+          entityType: 'program_assignment',
+          assignedProgramId: mockProgramId,
+          routingDecision,
+        },
+      });
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      const result = await service.logRouteEvent(
+        mockRequestId,
+        mockProgramId,
+        routingDecision,
+      );
+
+      expect(result.eventType).toBe('ROUTE');
+      expect(result.requestDetails).toHaveProperty('assignedProgramId', mockProgramId);
+      expect(result.requestDetails).toHaveProperty('routingDecision', routingDecision);
+    });
+
+    it('should throw error on failure', async () => {
+      const mockSave = jest.fn().mockRejectedValue(new Error('Save failed'));
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      await expect(
+        service.logRouteEvent(mockRequestId, mockProgramId, {}),
+      ).rejects.toThrow('Save failed');
+    });
+  });
+
+  describe('logFallbackEvent', () => {
+    it('should log FALLBACK event with reason', async () => {
+      const originalProgramId = 'PROG-INVALID';
+      const fallbackProgramId = 'PROG-DEFAULT';
+      const reason = 'Original program inactive';
+
+      const mockSave = jest.fn().mockResolvedValue({
+        _id: 'test-id',
+        requestId: mockRequestId,
+        eventType: 'FALLBACK',
+        actorId: 'system',
+        requestDetails: {
+          entityType: 'program_fallback',
+          originalProgramId,
+          fallbackProgramId,
+          reason,
+        },
+      });
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      const result = await service.logFallbackEvent(
+        mockRequestId,
+        originalProgramId,
+        fallbackProgramId,
+        reason,
+      );
+
+      expect(result.eventType).toBe('FALLBACK');
+      expect(result.requestDetails).toHaveProperty('originalProgramId', originalProgramId);
+      expect(result.requestDetails).toHaveProperty('fallbackProgramId', fallbackProgramId);
+      expect(result.requestDetails).toHaveProperty('reason', reason);
+    });
+
+    it('should throw error on failure', async () => {
+      const mockSave = jest.fn().mockRejectedValue(new Error('Database error'));
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      await expect(
+        service.logFallbackEvent(mockRequestId, 'prog1', 'prog2', 'test'),
+      ).rejects.toThrow('Database error');
+    });
+  });
+
+  describe('logRouteAssignedEvent', () => {
+    it('should log ROUTE_ASSIGNED event with all details', async () => {
+      const routingDecision = { rule: 'TARGET_PROGRAM' };
+      const validationResult = { isValid: true };
+      const troubleshootingInfo = { attemptCount: 1 };
+
+      const mockSave = jest.fn().mockResolvedValue({
+        _id: 'test-id',
+        requestId: mockRequestId,
+        eventType: 'ROUTE_ASSIGNED',
+        actorId: 'system',
+        requestDetails: {
+          entityType: 'route_assignment',
+          finalProgramId: mockProgramId,
+          routingDecision,
+          validationResult,
+          troubleshootingInfo,
+        },
+      });
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      const result = await service.logRouteAssignedEvent(
+        mockRequestId,
+        mockProgramId,
+        routingDecision,
+        validationResult,
+        troubleshootingInfo,
+      );
+
+      expect(result.eventType).toBe('ROUTE_ASSIGNED');
+      expect(result.requestDetails).toHaveProperty('finalProgramId', mockProgramId);
+      expect(result.requestDetails).toHaveProperty('routingDecision');
+      expect(result.requestDetails).toHaveProperty('validationResult');
+      expect(result.requestDetails).toHaveProperty('troubleshootingInfo');
+    });
+
+    it('should throw error on failure', async () => {
+      const mockSave = jest.fn().mockRejectedValue(new Error('Save failed'));
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      await expect(
+        service.logRouteAssignedEvent(mockRequestId, mockProgramId, {}, {}, {}),
+      ).rejects.toThrow('Save failed');
+    });
+  });
+
+  describe('getAuditHistory', () => {
+    it('should retrieve audit history for a request', async () => {
+      const mockHistory = [
+        {
+          _id: '1',
+          requestId: mockRequestId,
+          eventType: 'CREATE',
+          timestamp: new Date(),
+        },
+        {
+          _id: '2',
+          requestId: mockRequestId,
+          eventType: 'RADICATE',
+          timestamp: new Date(),
+        },
+      ];
+
+      const mockSort = jest.fn().mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockHistory),
+      });
+
+      jest.spyOn(auditModel, 'find').mockReturnValue({
+        sort: mockSort,
+      } as any);
+
+      const result = await service.getAuditHistory(mockRequestId);
+
+      expect(auditModel.find).toHaveBeenCalledWith({ requestId: mockRequestId });
+      expect(mockSort).toHaveBeenCalledWith({ timestamp: -1 });
+      expect(result).toHaveLength(2);
+      expect(result[0].eventType).toBe('CREATE');
+    });
+
+    it('should return empty array when no history found', async () => {
+      const mockSort = jest.fn().mockReturnValue({
+        exec: jest.fn().mockResolvedValue([]),
+      });
+
+      jest.spyOn(auditModel, 'find').mockReturnValue({
+        sort: mockSort,
+      } as any);
+
+      const result = await service.getAuditHistory(mockRequestId);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw error on database failure', async () => {
+      const mockSort = jest.fn().mockReturnValue({
+        exec: jest.fn().mockRejectedValue(new Error('Database error')),
+      });
+
+      jest.spyOn(auditModel, 'find').mockReturnValue({
+        sort: mockSort,
+      } as any);
+
+      await expect(service.getAuditHistory(mockRequestId)).rejects.toThrow(
+        'Database error',
+      );
+    });
+  });
+
+  describe('Integration scenarios', () => {
+    it('should handle complete audit workflow', async () => {
+      const mockSave = jest.fn()
+        .mockResolvedValueOnce({
+          _id: 'test-id',
+          requestId: mockRequestId,
+          eventType: 'CREATE',
+          actorId: mockActorId,
+        });
+
+      (auditModel as any).mockConstructor = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      const mockSort = jest.fn().mockReturnValue({
+        exec: jest.fn().mockResolvedValue([
+          { _id: '1', eventType: 'CREATE', requestId: mockRequestId },
+        ]),
+      });
+
+      jest.spyOn(auditModel, 'find').mockReturnValue({
+        sort: mockSort,
+      } as any);
+
+      // Testear solo la consulta de historial (ya testeamos create en otros tests)
+      const history = await service.getAuditHistory(mockRequestId);
+
+      expect(auditModel.find).toHaveBeenCalledWith({ requestId: mockRequestId });
+      expect(history).toHaveLength(1);
+      expect(history[0].eventType).toBe('CREATE');
+    });
+
+    it('should log multiple events in sequence', async () => {
+      const mockSave = jest.fn()
+        .mockResolvedValueOnce({
+          _id: '1',
+          eventType: 'CREATE',
+          requestId: mockRequestId,
+        })
+        .mockResolvedValueOnce({
+          _id: '2',
+          eventType: 'RADICATE',
+          requestId: mockRequestId,
+        })
+        .mockResolvedValueOnce({
+          _id: '3',
+          eventType: 'ROUTE',
+          requestId: mockRequestId,
+        });
+
+      (auditModel as any) = jest.fn().mockImplementation(() => ({
+        save: mockSave,
+      }));
+
+      service = new AuditService(auditModel);
+
+      await service.logCreateEvent(mockRequestId, mockActorId, {});
+      await service.logRadicateEvent(mockRequestId, mockRadicado, 'NORMAL', {});
+      await service.logRouteEvent(mockRequestId, mockProgramId, {});
+
+      expect(mockSave).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/src/test/change-requests.controller.spec.ts
+++ b/src/test/change-requests.controller.spec.ts
@@ -1,0 +1,370 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChangeRequestsController } from '../change-requests/change-requests.controller';
+import { ChangeRequestsService } from '../change-requests/services/change-requests.service';
+import { CreateChangeRequestDto } from '../change-requests/dto/create-change-request.dto';
+import {
+  ApproveChangeRequestDto,
+  RejectChangeRequestDto,
+} from '../change-requests/dto/change-request-response.dto';
+import { RequestState } from '../change-requests/entities/change-request.entity';
+
+describe('ChangeRequestsController', () => {
+  let controller: ChangeRequestsController;
+  let service: ChangeRequestsService;
+
+  const mockChangeRequest = {
+    _id: '60d5ecb8b0a7c4b4b8b9b1a4',
+    userId: 'user123',
+    sourceSubjectId: 'subject001',
+    targetSubjectId: 'subject002',
+    sourceGroupId: 'group001',
+    targetGroupId: 'group002',
+    status: 'PENDING',
+    radicado: '2024-001',
+    priority: 'NORMAL',
+    requestHash: 'hash123',
+    createdAt: new Date(),
+  };
+
+  const mockRequest = {
+    user: {
+      id: 'user123',
+      email: 'student@test.com',
+    },
+    ip: '192.168.1.1',
+    headers: {
+      'user-agent': 'Mozilla/5.0',
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ChangeRequestsController],
+      providers: [
+        {
+          provide: ChangeRequestsService,
+          useValue: {
+            create: jest.fn().mockResolvedValue(mockChangeRequest),
+            getRequestsByFaculty: jest.fn().mockResolvedValue([mockChangeRequest]),
+            getRequestDetails: jest.fn().mockResolvedValue(mockChangeRequest),
+            approveChangeRequest: jest
+              .fn()
+              .mockResolvedValue({ ...mockChangeRequest, status: 'APPROVED' }),
+            rejectChangeRequest: jest
+              .fn()
+              .mockResolvedValue({ ...mockChangeRequest, status: 'REJECTED' }),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ChangeRequestsController>(ChangeRequestsController);
+    service = module.get<ChangeRequestsService>(ChangeRequestsService);
+  });
+
+  describe('createChangeRequest', () => {
+    it('should create a change request', async () => {
+      const createDto: CreateChangeRequestDto = {
+        sourceSubjectId: 'subject001',
+        targetSubjectId: 'subject002',
+        sourceGroupId: 'group001',
+        targetGroupId: 'group002',
+        reason: 'Schedule conflict',
+      };
+
+      const result = await controller.createChangeRequest(mockRequest, createDto);
+
+      expect(result).toEqual(mockChangeRequest);
+      expect(service.create).toHaveBeenCalledWith(
+        createDto,
+        'user123',
+        '192.168.1.1',
+        'Mozilla/5.0',
+      );
+    });
+
+    it('should handle anonymous user', async () => {
+      const anonymousRequest = {
+        user: null,
+        ip: '192.168.1.1',
+        headers: { 'user-agent': 'Mozilla/5.0' },
+      };
+
+      const createDto: CreateChangeRequestDto = {
+        sourceSubjectId: 'subject001',
+        targetSubjectId: 'subject002',
+        sourceGroupId: 'group001',
+        targetGroupId: 'group002',
+        reason: 'Test',
+      };
+
+      await controller.createChangeRequest(anonymousRequest, createDto);
+
+      expect(service.create).toHaveBeenCalledWith(
+        createDto,
+        'anonymous',
+        '192.168.1.1',
+        'Mozilla/5.0',
+      );
+    });
+
+    it('should extract ip and user-agent from request', async () => {
+      const createDto: CreateChangeRequestDto = {
+        sourceSubjectId: 'subject001',
+        targetSubjectId: 'subject002',
+        sourceGroupId: 'group001',
+        targetGroupId: 'group002',
+        reason: 'Test',
+      };
+
+      await controller.createChangeRequest(mockRequest, createDto);
+
+      expect(service.create).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(String),
+        '192.168.1.1',
+        'Mozilla/5.0',
+      );
+    });
+  });
+
+  describe('getRequestsByFaculty', () => {
+    it('should get requests by faculty with all filters', async () => {
+      const facultyId = 'faculty123';
+      const status = RequestState.PENDING;
+      const periodId = 'period123';
+      const studentId = 'student123';
+
+      const result = await controller.getRequestsByFaculty(
+        facultyId,
+        status,
+        periodId,
+        studentId,
+      );
+
+      expect(result).toEqual([mockChangeRequest]);
+      expect(service.getRequestsByFaculty).toHaveBeenCalledWith(facultyId, {
+        status,
+        periodId,
+        studentId,
+      });
+    });
+
+    it('should get requests by faculty without filters', async () => {
+      const facultyId = 'faculty123';
+
+      const result = await controller.getRequestsByFaculty(facultyId);
+
+      expect(result).toEqual([mockChangeRequest]);
+      expect(service.getRequestsByFaculty).toHaveBeenCalledWith(facultyId, {
+        status: undefined,
+        periodId: undefined,
+        studentId: undefined,
+      });
+    });
+
+    it('should get requests by faculty with only status filter', async () => {
+      const facultyId = 'faculty123';
+      const status = RequestState.APPROVED;
+
+      const result = await controller.getRequestsByFaculty(facultyId, status);
+
+      expect(result).toEqual([mockChangeRequest]);
+      expect(service.getRequestsByFaculty).toHaveBeenCalledWith(facultyId, {
+        status,
+        periodId: undefined,
+        studentId: undefined,
+      });
+    });
+
+    it('should handle multiple request states', async () => {
+      const facultyId = 'faculty123';
+
+      await controller.getRequestsByFaculty(facultyId, RequestState.PENDING);
+      await controller.getRequestsByFaculty(facultyId, RequestState.APPROVED);
+      await controller.getRequestsByFaculty(facultyId, RequestState.REJECTED);
+
+      expect(service.getRequestsByFaculty).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('getRequestDetails', () => {
+    it('should get request details by id', async () => {
+      const requestId = '60d5ecb8b0a7c4b4b8b9b1a4';
+
+      const result = await controller.getRequestDetails(requestId);
+
+      expect(result).toEqual(mockChangeRequest);
+      expect(service.getRequestDetails).toHaveBeenCalledWith(requestId);
+    });
+
+    it('should call service with correct id', async () => {
+      const requestId = 'test-id-123';
+
+      await controller.getRequestDetails(requestId);
+
+      expect(service.getRequestDetails).toHaveBeenCalledWith(requestId);
+      expect(service.getRequestDetails).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('approveRequest', () => {
+    it('should approve a change request', async () => {
+      const requestId = '60d5ecb8b0a7c4b4b8b9b1a4';
+      const approveDto: ApproveChangeRequestDto = {
+        observations: 'Approved by dean',
+      };
+
+      const result = await controller.approveRequest(requestId, approveDto);
+
+      expect(result.status).toBe('APPROVED');
+      expect(service.approveChangeRequest).toHaveBeenCalledWith(requestId, approveDto);
+    });
+
+    it('should approve without observations', async () => {
+      const requestId = '60d5ecb8b0a7c4b4b8b9b1a4';
+      const approveDto: ApproveChangeRequestDto = {};
+
+      await controller.approveRequest(requestId, approveDto);
+
+      expect(service.approveChangeRequest).toHaveBeenCalledWith(requestId, approveDto);
+    });
+
+    it('should return approved request with updated status', async () => {
+      const requestId = '60d5ecb8b0a7c4b4b8b9b1a4';
+      const approveDto: ApproveChangeRequestDto = {
+        observations: 'Looks good',
+      };
+
+      const result = await controller.approveRequest(requestId, approveDto);
+
+      expect(result).toHaveProperty('status', 'APPROVED');
+      expect(result).toHaveProperty('_id', requestId);
+    });
+  });
+
+  describe('rejectRequest', () => {
+    it('should reject a change request', async () => {
+      const requestId = '60d5ecb8b0a7c4b4b8b9b1a4';
+      const rejectDto: RejectChangeRequestDto = {
+        resolutionReason: 'Does not meet requirements',
+        observations: 'Additional notes',
+      };
+
+      const result = await controller.rejectRequest(requestId, rejectDto);
+
+      expect(result.status).toBe('REJECTED');
+      expect(service.rejectChangeRequest).toHaveBeenCalledWith(requestId, rejectDto);
+    });
+
+    it('should reject without observations', async () => {
+      const requestId = '60d5ecb8b0a7c4b4b8b9b1a4';
+      const rejectDto: RejectChangeRequestDto = {
+        resolutionReason: 'Policy violation',
+      };
+
+      await controller.rejectRequest(requestId, rejectDto);
+
+      expect(service.rejectChangeRequest).toHaveBeenCalledWith(requestId, rejectDto);
+    });
+
+    it('should return rejected request with updated status', async () => {
+      const requestId = '60d5ecb8b0a7c4b4b8b9b1a4';
+      const rejectDto: RejectChangeRequestDto = {
+        resolutionReason: 'Conflicts with other enrollment',
+        observations: 'Student already enrolled',
+      };
+
+      const result = await controller.rejectRequest(requestId, rejectDto);
+
+      expect(result).toHaveProperty('status', 'REJECTED');
+      expect(result).toHaveProperty('_id', requestId);
+    });
+  });
+
+  describe('getMyRequests', () => {
+    it('should return placeholder message', async () => {
+      const result = await controller.getMyRequests(mockRequest);
+
+      expect(result).toHaveProperty('message', 'Feature coming soon');
+      expect(result).toHaveProperty('studentCode');
+    });
+
+    it('should extract student code from email', async () => {
+      const result = await controller.getMyRequests(mockRequest);
+
+      expect(result.studentCode).toBe('TEMP-CODE');
+    });
+
+    it('should handle missing user email', async () => {
+      const requestWithoutEmail = {
+        user: { id: 'user123' },
+      };
+
+      const result = await controller.getMyRequests(requestWithoutEmail);
+
+      expect(result).toHaveProperty('message', 'Feature coming soon');
+    });
+  });
+
+  describe('Integration scenarios', () => {
+    it('should handle complete request lifecycle', async () => {
+      const createDto: CreateChangeRequestDto = {
+        sourceSubjectId: 'subject001',
+        targetSubjectId: 'subject002',
+        sourceGroupId: 'group001',
+        targetGroupId: 'group002',
+        reason: 'Test',
+      };
+
+      // Create
+      const created = await controller.createChangeRequest(mockRequest, createDto);
+      expect(created.status).toBe('PENDING');
+
+      // Get details
+      const details = await controller.getRequestDetails(created._id as string);
+      expect(details._id).toBe(created._id);
+
+      // Approve
+      const approved = await controller.approveRequest(created._id as string, {
+        observations: 'Approved',
+      });
+      expect(approved.status).toBe('APPROVED');
+    });
+
+    it('should handle faculty workflow', async () => {
+      const facultyId = 'faculty123';
+
+      // Get all requests
+      const allRequests = await controller.getRequestsByFaculty(facultyId);
+      expect(Array.isArray(allRequests)).toBe(true);
+
+      // Get pending only
+      const pendingRequests = await controller.getRequestsByFaculty(
+        facultyId,
+        RequestState.PENDING,
+      );
+      expect(Array.isArray(pendingRequests)).toBe(true);
+    });
+
+    it('should handle rejection workflow', async () => {
+      const createDto: CreateChangeRequestDto = {
+        sourceSubjectId: 'subject001',
+        targetSubjectId: 'subject002',
+        sourceGroupId: 'group001',
+        targetGroupId: 'group002',
+        reason: 'Test',
+      };
+
+      // Create
+      const created = await controller.createChangeRequest(mockRequest, createDto);
+
+      // Reject
+      const rejected = await controller.rejectRequest(created._id as string, {
+        resolutionReason: 'Rejected due to policy',
+        observations: 'Additional info',
+      });
+      expect(rejected.status).toBe('REJECTED');
+    });
+  });
+});

--- a/src/test/change-requests.service.spec.ts
+++ b/src/test/change-requests.service.spec.ts
@@ -1,0 +1,522 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { BadRequestException } from '@nestjs/common';
+import { Model } from 'mongoose';
+import { ChangeRequestsService } from '../change-requests/services/change-requests.service';
+import { ChangeRequest, ChangeRequestDocument } from '../change-requests/entities/change-request.entity';
+import { CreateChangeRequestDto } from '../change-requests/dto/create-change-request.dto';
+import { AuditService } from '../common/services/audit.service';
+import { RadicadoService } from '../common/services/radicado.service';
+import { PriorityCalculatorService, Priority } from '../common/services/priority-calculator.service';
+import { RoutingService } from '../common/services/routing.service';
+import { RoutingValidatorService } from '../common/services/routing-validator.service';
+
+describe('ChangeRequestsService', () => {
+  let service: ChangeRequestsService;
+  let changeRequestModel: Model<ChangeRequestDocument>;
+  let auditService: AuditService;
+  let radicadoService: RadicadoService;
+  let priorityCalculatorService: PriorityCalculatorService;
+  let routingService: RoutingService;
+  let routingValidatorService: RoutingValidatorService;
+
+  const mockUserId = '60d5ecb8b0a7c4b4b8b9b1a1';
+  const mockSourceSubjectId = '60d5ecb8b0a7c4b4b8b9b1a2';
+  const mockTargetSubjectId = '60d5ecb8b0a7c4b4b8b9b1a3';
+  const mockProgramId = 'PROG-CS';
+  const mockRadicado = '2024-001';
+  const mockRequestId = '60d5ecb8b0a7c4b4b8b9b1a4';
+
+  const mockCreateDto: CreateChangeRequestDto = {
+    sourceSubjectId: mockSourceSubjectId,
+    targetSubjectId: mockTargetSubjectId,
+    sourceGroupId: 'group-001',
+    targetGroupId: 'group-002',
+    reason: 'Test reason',
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChangeRequestsService,
+        {
+          provide: getModelToken(ChangeRequest.name),
+          useValue: {
+            findOne: jest.fn(),
+            find: jest.fn(),
+            findById: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: AuditService,
+          useValue: {
+            logCreateEvent: jest.fn().mockResolvedValue({}),
+            logRadicateEvent: jest.fn().mockResolvedValue({}),
+            logRouteEvent: jest.fn().mockResolvedValue({}),
+            logFallbackEvent: jest.fn().mockResolvedValue({}),
+            logRouteAssignedEvent: jest.fn().mockResolvedValue({}),
+          },
+        },
+        {
+          provide: RadicadoService,
+          useValue: {
+            generateRadicado: jest.fn().mockResolvedValue(mockRadicado),
+          },
+        },
+        {
+          provide: PriorityCalculatorService,
+          useValue: {
+            calculatePriority: jest.fn().mockReturnValue(Priority.NORMAL),
+            isAddDropPeriod: jest.fn().mockReturnValue(false),
+            getPriorityDescription: jest.fn().mockReturnValue('Normal priority'),
+            getPriorityWeight: jest.fn().mockReturnValue(2),
+          },
+        },
+        {
+          provide: RoutingService,
+          useValue: {
+            determineProgram: jest.fn().mockResolvedValue({
+              assignedProgramId: mockProgramId,
+              reason: 'Same program',
+              rule: 'SAME_PROGRAM',
+            }),
+          },
+        },
+        {
+          provide: RoutingValidatorService,
+          useValue: {
+            validateAndEnsureProgram: jest.fn().mockResolvedValue({
+              isValid: true,
+              assignedProgramId: mockProgramId,
+              fallbackUsed: false,
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ChangeRequestsService>(ChangeRequestsService);
+    changeRequestModel = module.get<Model<ChangeRequestDocument>>(
+      getModelToken(ChangeRequest.name),
+    );
+    auditService = module.get<AuditService>(AuditService);
+    radicadoService = module.get<RadicadoService>(RadicadoService);
+    priorityCalculatorService = module.get<PriorityCalculatorService>(
+      PriorityCalculatorService,
+    );
+    routingService = module.get<RoutingService>(RoutingService);
+    routingValidatorService = module.get<RoutingValidatorService>(
+      RoutingValidatorService,
+    );
+  });
+
+  describe('create', () => {
+    it('should throw error when source equals target', async () => {
+      const invalidDto: CreateChangeRequestDto = {
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockSourceSubjectId,
+        sourceGroupId: 'group-001',
+        targetGroupId: 'group-001',
+        reason: 'Test',
+      };
+
+      await expect(service.create(invalidDto, mockUserId)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.create(invalidDto, mockUserId)).rejects.toThrow(
+        'La materia origen no puede ser igual a la materia destino',
+      );
+    });
+
+    it('should return existing request if duplicate found', async () => {
+      const existingRequest = {
+        _id: mockRequestId,
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        status: 'PENDING',
+        radicado: mockRadicado,
+      };
+
+      jest.spyOn(changeRequestModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(existingRequest),
+      } as any);
+
+      // También mockear el findOne directo para que retorne el request existente
+      (changeRequestModel.findOne as jest.Mock).mockResolvedValue(existingRequest);
+
+      const result = await service.create(mockCreateDto, mockUserId);
+
+      expect(result).toEqual(existingRequest);
+      expect(radicadoService.generateRadicado).not.toHaveBeenCalled();
+    });
+
+    it('should create new change request successfully', async () => {
+      const savedRequest = {
+        _id: mockRequestId,
+        userId: mockUserId,
+        ...mockCreateDto,
+        status: 'PENDING',
+        priority: Priority.NORMAL,
+        assignedProgramId: mockProgramId,
+        radicado: mockRadicado,
+      };
+
+      jest.spyOn(changeRequestModel, 'findOne').mockResolvedValue(null);
+
+      const mockSave = jest.fn().mockResolvedValue(savedRequest);
+      const mockConstructor = jest.fn().mockImplementation((data: any) => ({
+        ...data,
+        save: mockSave,
+      }));
+
+      // Reemplazar temporalmente el constructor del modelo
+      const originalModel = (service as any).changeRequestModel;
+      (service as any).changeRequestModel = mockConstructor as any;
+      Object.assign((service as any).changeRequestModel, {
+        findOne: originalModel.findOne,
+        find: originalModel.find,
+        findById: originalModel.findById,
+      });
+
+      const result = await service.create(mockCreateDto, mockUserId);
+
+      expect(radicadoService.generateRadicado).toHaveBeenCalled();
+      expect(priorityCalculatorService.calculatePriority).toHaveBeenCalled();
+      expect(routingService.determineProgram).toHaveBeenCalled();
+      expect(routingValidatorService.validateAndEnsureProgram).toHaveBeenCalled();
+      expect(mockSave).toHaveBeenCalled();
+
+      // Restaurar
+      (service as any).changeRequestModel = originalModel;
+    });
+
+    it('should log all audit events for new request', async () => {
+      const savedRequest = {
+        _id: mockRequestId,
+        userId: mockUserId,
+        ...mockCreateDto,
+        status: 'PENDING',
+        priority: Priority.NORMAL,
+        assignedProgramId: mockProgramId,
+        radicado: mockRadicado,
+      };
+
+      jest.spyOn(changeRequestModel, 'findOne').mockResolvedValue(null);
+
+      const mockSave = jest.fn().mockResolvedValue(savedRequest);
+      const mockConstructor = jest.fn().mockImplementation(() => ({
+        ...savedRequest,
+        save: mockSave,
+      }));
+
+      const originalModel = (service as any).changeRequestModel;
+      (service as any).changeRequestModel = mockConstructor as any;
+      Object.assign((service as any).changeRequestModel, {
+        findOne: originalModel.findOne,
+        find: originalModel.find,
+        findById: originalModel.findById,
+      });
+
+      await service.create(mockCreateDto, mockUserId);
+
+      expect(auditService.logCreateEvent).toHaveBeenCalled();
+      expect(auditService.logRadicateEvent).toHaveBeenCalled();
+      expect(auditService.logRouteEvent).toHaveBeenCalled();
+      expect(auditService.logRouteAssignedEvent).toHaveBeenCalled();
+
+      (service as any).changeRequestModel = originalModel;
+    });
+
+    it('should log fallback event when fallback is used', async () => {
+      const savedRequest = {
+        _id: mockRequestId,
+        userId: mockUserId,
+        ...mockCreateDto,
+        status: 'PENDING',
+        priority: Priority.NORMAL,
+        assignedProgramId: 'PROG-ADMIN',
+        radicado: mockRadicado,
+      };
+
+      jest.spyOn(changeRequestModel, 'findOne').mockResolvedValue(null);
+
+      jest.spyOn(routingValidatorService, 'validateAndEnsureProgram').mockResolvedValue({
+        isValid: true,
+        assignedProgramId: 'PROG-ADMIN',
+        fallbackUsed: true,
+        reason: 'Original program inactive',
+      });
+
+      const mockSave = jest.fn().mockResolvedValue(savedRequest);
+      const mockConstructor = jest.fn().mockImplementation(() => ({
+        ...savedRequest,
+        save: mockSave,
+      }));
+
+      const originalModel = (service as any).changeRequestModel;
+      (service as any).changeRequestModel = mockConstructor as any;
+      Object.assign((service as any).changeRequestModel, {
+        findOne: originalModel.findOne,
+        find: originalModel.find,
+        findById: originalModel.findById,
+      });
+
+      await service.create(mockCreateDto, mockUserId);
+
+      expect(auditService.logFallbackEvent).toHaveBeenCalled();
+
+      (service as any).changeRequestModel = originalModel;
+    });
+
+    it('should include ipAddress and userAgent in audit', async () => {
+      const savedRequest = {
+        _id: mockRequestId,
+        userId: mockUserId,
+        ...mockCreateDto,
+        status: 'PENDING',
+        priority: Priority.NORMAL,
+        assignedProgramId: mockProgramId,
+        radicado: mockRadicado,
+      };
+
+      jest.spyOn(changeRequestModel, 'findOne').mockResolvedValue(null);
+
+      const mockSave = jest.fn().mockResolvedValue(savedRequest);
+      const mockConstructor = jest.fn().mockImplementation(() => ({
+        ...savedRequest,
+        save: mockSave,
+      }));
+
+      const originalModel = (service as any).changeRequestModel;
+      (service as any).changeRequestModel = mockConstructor as any;
+      Object.assign((service as any).changeRequestModel, {
+        findOne: originalModel.findOne,
+        find: originalModel.find,
+        findById: originalModel.findById,
+      });
+
+      const ipAddress = '192.168.1.1';
+      const userAgent = 'Mozilla/5.0';
+
+      await service.create(mockCreateDto, mockUserId, ipAddress, userAgent);
+
+      expect(auditService.logCreateEvent).toHaveBeenCalledWith(
+        expect.any(String),
+        mockUserId,
+        expect.any(Object),
+        ipAddress,
+        userAgent,
+      );
+
+      (service as any).changeRequestModel = originalModel;
+    });
+  });
+
+  describe('findByUser', () => {
+    it('should return user requests sorted by date', async () => {
+      const mockRequests = [
+        { _id: '1', userId: mockUserId, createdAt: new Date('2024-01-02') },
+        { _id: '2', userId: mockUserId, createdAt: new Date('2024-01-01') },
+      ];
+
+      const mockSort = jest.fn().mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockRequests),
+      });
+
+      jest.spyOn(changeRequestModel, 'find').mockReturnValue({
+        sort: mockSort,
+      } as any);
+
+      const result = await service.findByUser(mockUserId);
+
+      expect(changeRequestModel.find).toHaveBeenCalledWith({ userId: mockUserId });
+      expect(mockSort).toHaveBeenCalledWith({ createdAt: -1 });
+      expect(result).toEqual(mockRequests);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return request by ID', async () => {
+      const mockRequest = {
+        _id: mockRequestId,
+        userId: mockUserId,
+        status: 'PENDING',
+      };
+
+      jest.spyOn(changeRequestModel, 'findById').mockResolvedValue(mockRequest as any);
+
+      const result = await service.findOne(mockRequestId);
+
+      expect(result).toEqual(mockRequest);
+    });
+
+    it('should throw error if request not found', async () => {
+      jest.spyOn(changeRequestModel, 'findById').mockResolvedValue(null);
+
+      await expect(service.findOne('nonexistent')).rejects.toThrow(BadRequestException);
+      await expect(service.findOne('nonexistent')).rejects.toThrow(
+        'Solicitud no encontrada',
+      );
+    });
+  });
+
+  describe('getRequestsByFaculty', () => {
+    it('should get requests by faculty with filters', async () => {
+      const mockRequests = [{ _id: '1', assignedProgramId: mockProgramId }];
+      const filters = { status: 'PENDING', studentId: mockUserId };
+
+      const mockSort = jest.fn().mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockRequests),
+      });
+
+      jest.spyOn(changeRequestModel, 'find').mockReturnValue({
+        sort: mockSort,
+      } as any);
+
+      const result = await service.getRequestsByFaculty(mockProgramId, filters);
+
+      expect(changeRequestModel.find).toHaveBeenCalledWith({
+        assignedProgramId: mockProgramId,
+        status: 'PENDING',
+        userId: mockUserId,
+      });
+      expect(result).toEqual(mockRequests);
+    });
+
+    it('should work without filters', async () => {
+      const mockRequests = [{ _id: '1', assignedProgramId: mockProgramId }];
+
+      const mockSort = jest.fn().mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockRequests),
+      });
+
+      jest.spyOn(changeRequestModel, 'find').mockReturnValue({
+        sort: mockSort,
+      } as any);
+
+      const result = await service.getRequestsByFaculty(mockProgramId, {});
+
+      expect(changeRequestModel.find).toHaveBeenCalledWith({
+        assignedProgramId: mockProgramId,
+      });
+    });
+  });
+
+  describe('getRequestDetails', () => {
+    it('should return request details', async () => {
+      const mockRequest = { _id: mockRequestId, userId: mockUserId };
+
+      jest.spyOn(changeRequestModel, 'findById').mockResolvedValue(mockRequest as any);
+
+      const result = await service.getRequestDetails(mockRequestId);
+
+      expect(result).toEqual(mockRequest);
+    });
+  });
+
+  describe('approveChangeRequest', () => {
+    it('should approve pending request', async () => {
+      const mockRequest = {
+        _id: mockRequestId,
+        userId: mockUserId,
+        status: 'PENDING',
+        save: jest.fn().mockImplementation(function (this: any) {
+          return Promise.resolve({ ...this, status: 'APPROVED' });
+        }),
+      };
+
+      jest.spyOn(changeRequestModel, 'findById').mockResolvedValue(mockRequest as any);
+
+      const result = await service.approveChangeRequest(mockRequestId, {});
+
+      expect(mockRequest.status).toBe('APPROVED');
+      expect(mockRequest.save).toHaveBeenCalled();
+    });
+
+    it('should add observations when approving', async () => {
+      const mockRequest = {
+        _id: mockRequestId,
+        userId: mockUserId,
+        status: 'PENDING',
+        observations: undefined,
+        save: jest.fn().mockResolvedValue(this),
+      };
+
+      jest.spyOn(changeRequestModel, 'findById').mockResolvedValue(mockRequest as any);
+
+      await service.approveChangeRequest(mockRequestId, {
+        observations: 'Approved with conditions',
+      });
+
+      expect(mockRequest.observations).toBe('Approved with conditions');
+    });
+
+    it('should throw error if request not pending', async () => {
+      const mockRequest = {
+        _id: mockRequestId,
+        userId: mockUserId,
+        status: 'APPROVED',
+      };
+
+      jest.spyOn(changeRequestModel, 'findById').mockResolvedValue(mockRequest as any);
+
+      await expect(
+        service.approveChangeRequest(mockRequestId, {}),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('rejectChangeRequest', () => {
+    it('should reject pending request', async () => {
+      const mockRequest = {
+        _id: mockRequestId,
+        userId: mockUserId,
+        status: 'PENDING',
+        save: jest.fn().mockImplementation(function (this: any) {
+          return Promise.resolve({ ...this, status: 'REJECTED' });
+        }),
+      };
+
+      jest.spyOn(changeRequestModel, 'findById').mockResolvedValue(mockRequest as any);
+
+      const result = await service.rejectChangeRequest(mockRequestId, {});
+
+      expect(mockRequest.status).toBe('REJECTED');
+      expect(mockRequest.save).toHaveBeenCalled();
+    });
+
+    it('should add observations when rejecting', async () => {
+      const mockRequest = {
+        _id: mockRequestId,
+        userId: mockUserId,
+        status: 'PENDING',
+        observations: undefined,
+        save: jest.fn().mockResolvedValue(this),
+      };
+
+      jest.spyOn(changeRequestModel, 'findById').mockResolvedValue(mockRequest as any);
+
+      await service.rejectChangeRequest(mockRequestId, {
+        observations: 'Rejected due to conflicts',
+      });
+
+      expect(mockRequest.observations).toBe('Rejected due to conflicts');
+    });
+
+    it('should throw error if request not pending', async () => {
+      const mockRequest = {
+        _id: mockRequestId,
+        userId: mockUserId,
+        status: 'REJECTED',
+      };
+
+      jest.spyOn(changeRequestModel, 'findById').mockResolvedValue(mockRequest as any);
+
+      await expect(
+        service.rejectChangeRequest(mockRequestId, {}),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/src/test/change-windows.controller.spec.ts
+++ b/src/test/change-windows.controller.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChangeWindowsController } from '../change-windows/change-windows.controller';
+import { ChangeWindowsService } from '../change-windows/services/change-windows.service';
+import { CreateChangeWindowDto } from '../change-windows/dto/create-change-window.dto';
+import { UpdateChangeWindowDto } from '../change-windows/dto/update-change-window.dto';
+
+describe('ChangeWindowsController', () => {
+  let controller: ChangeWindowsController;
+  let service: ChangeWindowsService;
+
+  const mockChangeWindowsService = {
+    create: jest.fn().mockReturnValue('This action adds a new changeWindow'),
+    findAll: jest.fn().mockReturnValue(['This action returns all changeWindows']),
+    findOne: jest.fn().mockReturnValue('This action returns a #1 changeWindow'),
+    update: jest.fn().mockReturnValue('This action updates a #1 changeWindow'),
+    remove: jest.fn().mockReturnValue('This action removes a #1 changeWindow'),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ChangeWindowsController],
+      providers: [
+        {
+          provide: ChangeWindowsService,
+          useValue: mockChangeWindowsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ChangeWindowsController>(ChangeWindowsController);
+    service = module.get<ChangeWindowsService>(ChangeWindowsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a new changeWindow', () => {
+      const createDto: CreateChangeWindowDto = {} as any;
+      const result = controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledWith(createDto);
+      expect(result).toBe('This action adds a new changeWindow');
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all changeWindows', () => {
+      const result = controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toEqual(['This action returns all changeWindows']);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single changeWindow', () => {
+      const id = '1';
+      const result = controller.findOne(id);
+
+      expect(service.findOne).toHaveBeenCalledWith(1);
+      expect(result).toBe('This action returns a #1 changeWindow');
+    });
+  });
+
+  describe('update', () => {
+    it('should update a changeWindow', () => {
+      const id = '1';
+      const updateDto: UpdateChangeWindowDto = {} as any;
+      const result = controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(1, updateDto);
+      expect(result).toBe('This action updates a #1 changeWindow');
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a changeWindow', () => {
+      const id = '1';
+      const result = controller.remove(id);
+
+      expect(service.remove).toHaveBeenCalledWith(1);
+      expect(result).toBe('This action removes a #1 changeWindow');
+    });
+  });
+});

--- a/src/test/course-groups.controller.spec.ts
+++ b/src/test/course-groups.controller.spec.ts
@@ -1,0 +1,282 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CourseGroupsController } from '../course-groups/course-groups.controller';
+import { CourseGroupsService } from '../course-groups/services/course-groups.service';
+import { CreateCourseGroupDto } from '../course-groups/dto/create-course-group.dto';
+import { UpdateCourseGroupDto } from '../course-groups/dto/update-course-group.dto';
+
+describe('CourseGroupsController', () => {
+  let controller: CourseGroupsController;
+  let service: CourseGroupsService;
+
+  const mockCourseGroup = {
+    _id: '507f1f77bcf86cd799439011',
+    courseId: '507f1f77bcf86cd799439012',
+    groupNumber: 'G01',
+    periodId: '507f1f77bcf86cd799439013',
+    maxStudents: 30,
+    currentEnrollments: 15,
+    professorId: '507f1f77bcf86cd799439014',
+    isActive: true,
+    classroom: 'A-201',
+    observations: 'Regular group',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockCourseGroupsService = {
+    create: jest.fn().mockResolvedValue(mockCourseGroup),
+    findAll: jest.fn().mockResolvedValue([mockCourseGroup]),
+    getAvailableGroups: jest.fn().mockResolvedValue([mockCourseGroup]),
+    findByPeriod: jest.fn().mockResolvedValue([mockCourseGroup]),
+    findByCourse: jest.fn().mockResolvedValue([mockCourseGroup]),
+    findOne: jest.fn().mockResolvedValue(mockCourseGroup),
+    update: jest.fn().mockResolvedValue({ ...mockCourseGroup, maxStudents: 35 }),
+    remove: jest.fn().mockResolvedValue({ deleted: true }),
+    updateEnrollmentCount: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CourseGroupsController],
+      providers: [
+        {
+          provide: CourseGroupsService,
+          useValue: mockCourseGroupsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<CourseGroupsController>(CourseGroupsController);
+    service = module.get<CourseGroupsService>(CourseGroupsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a course group', async () => {
+      const createDto: CreateCourseGroupDto = {
+        courseId: '507f1f77bcf86cd799439012',
+        groupNumber: 'G01',
+        periodId: '507f1f77bcf86cd799439013',
+        maxStudents: 30,
+        professorId: '507f1f77bcf86cd799439014',
+        isActive: true,
+        classroom: 'A-201',
+      };
+
+      const result = await controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledWith(createDto);
+      expect(result).toEqual(mockCourseGroup);
+    });
+
+    it('should create a course group with minimal data', async () => {
+      const createDto: CreateCourseGroupDto = {
+        courseId: '507f1f77bcf86cd799439012',
+        groupNumber: 'G01',
+        periodId: '507f1f77bcf86cd799439013',
+        maxStudents: 30,
+      };
+
+      const result = await controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledWith(createDto);
+      expect(result).toEqual(mockCourseGroup);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of course groups', async () => {
+      const result = await controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toEqual([mockCourseGroup]);
+    });
+  });
+
+  describe('getAvailable', () => {
+    it('should return available course groups without filters', async () => {
+      const result = await controller.getAvailable();
+
+      expect(service.getAvailableGroups).toHaveBeenCalledWith(undefined, undefined);
+      expect(result).toEqual([mockCourseGroup]);
+    });
+
+    it('should return available course groups filtered by courseId', async () => {
+      const courseId = '507f1f77bcf86cd799439012';
+      const result = await controller.getAvailable(courseId);
+
+      expect(service.getAvailableGroups).toHaveBeenCalledWith(courseId, undefined);
+      expect(result).toEqual([mockCourseGroup]);
+    });
+
+    it('should return available course groups filtered by periodId', async () => {
+      const periodId = '507f1f77bcf86cd799439013';
+      const result = await controller.getAvailable(undefined, periodId);
+
+      expect(service.getAvailableGroups).toHaveBeenCalledWith(undefined, periodId);
+      expect(result).toEqual([mockCourseGroup]);
+    });
+
+    it('should return available course groups filtered by courseId and periodId', async () => {
+      const courseId = '507f1f77bcf86cd799439012';
+      const periodId = '507f1f77bcf86cd799439013';
+      const result = await controller.getAvailable(courseId, periodId);
+
+      expect(service.getAvailableGroups).toHaveBeenCalledWith(courseId, periodId);
+      expect(result).toEqual([mockCourseGroup]);
+    });
+  });
+
+  describe('findByPeriod', () => {
+    it('should return course groups for a specific period', async () => {
+      const periodId = '507f1f77bcf86cd799439013';
+      const result = await controller.findByPeriod(periodId);
+
+      expect(service.findByPeriod).toHaveBeenCalledWith(periodId);
+      expect(result).toEqual([mockCourseGroup]);
+    });
+  });
+
+  describe('findByCourse', () => {
+    it('should return course groups for a specific course', async () => {
+      const courseId = '507f1f77bcf86cd799439012';
+      const result = await controller.findByCourse(courseId);
+
+      expect(service.findByCourse).toHaveBeenCalledWith(courseId, undefined);
+      expect(result).toEqual([mockCourseGroup]);
+    });
+
+    it('should return course groups for a specific course and period', async () => {
+      const courseId = '507f1f77bcf86cd799439012';
+      const periodId = '507f1f77bcf86cd799439013';
+      const result = await controller.findByCourse(courseId, periodId);
+
+      expect(service.findByCourse).toHaveBeenCalledWith(courseId, periodId);
+      expect(result).toEqual([mockCourseGroup]);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single course group', async () => {
+      const id = '507f1f77bcf86cd799439011';
+      const result = await controller.findOne(id);
+
+      expect(service.findOne).toHaveBeenCalledWith(id);
+      expect(result).toEqual(mockCourseGroup);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a course group', async () => {
+      const id = '507f1f77bcf86cd799439011';
+      const updateDto: UpdateCourseGroupDto = {
+        maxStudents: 35,
+      };
+
+      const result = await controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(id, updateDto);
+      expect(result).toEqual({ ...mockCourseGroup, maxStudents: 35 });
+    });
+
+    it('should update course group classroom and professor', async () => {
+      const id = '507f1f77bcf86cd799439011';
+      const updateDto: UpdateCourseGroupDto = {
+        classroom: 'B-305',
+        professorId: '507f1f77bcf86cd799439015',
+      };
+
+      const result = await controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(id, updateDto);
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a course group', async () => {
+      const id = '507f1f77bcf86cd799439011';
+      const result = await controller.remove(id);
+
+      expect(service.remove).toHaveBeenCalledWith(id);
+      expect(result).toEqual({ deleted: true });
+    });
+  });
+
+  describe('updateEnrollmentCount', () => {
+    it('should update enrollment count and return success message', async () => {
+      const id = '507f1f77bcf86cd799439011';
+      const result = await controller.updateEnrollmentCount(id);
+
+      expect(service.updateEnrollmentCount).toHaveBeenCalledWith(id);
+      expect(result).toEqual({ message: 'Enrollment count updated successfully' });
+    });
+  });
+
+  // Integration scenarios
+  describe('Integration: Complete course group management lifecycle', () => {
+    it('should create, retrieve, update and delete a course group', async () => {
+      const createDto: CreateCourseGroupDto = {
+        courseId: '507f1f77bcf86cd799439012',
+        groupNumber: 'G01',
+        periodId: '507f1f77bcf86cd799439013',
+        maxStudents: 30,
+      };
+
+      // Create
+      const created = await controller.create(createDto);
+      expect(created).toEqual(mockCourseGroup);
+
+      // Find
+      const found = await controller.findOne(mockCourseGroup._id as string);
+      expect(found).toEqual(mockCourseGroup);
+
+      // Update
+      const updateDto: UpdateCourseGroupDto = { maxStudents: 35 };
+      const updated = await controller.update(mockCourseGroup._id as string, updateDto);
+      expect(updated).toBeDefined();
+
+      // Delete
+      const deleted = await controller.remove(mockCourseGroup._id as string);
+      expect(deleted).toEqual({ deleted: true });
+    });
+  });
+
+  describe('Integration: Available groups workflow', () => {
+    it('should filter available groups by course and period', async () => {
+      const courseId = '507f1f77bcf86cd799439012';
+      const periodId = '507f1f77bcf86cd799439013';
+
+      // Get available groups
+      const available = await controller.getAvailable(courseId, periodId);
+      expect(available).toEqual([mockCourseGroup]);
+      expect(service.getAvailableGroups).toHaveBeenCalledWith(courseId, periodId);
+
+      // Get by period
+      const byPeriod = await controller.findByPeriod(periodId);
+      expect(byPeriod).toEqual([mockCourseGroup]);
+
+      // Get by course
+      const byCourse = await controller.findByCourse(courseId, periodId);
+      expect(byCourse).toEqual([mockCourseGroup]);
+    });
+  });
+
+  describe('Integration: Enrollment count management', () => {
+    it('should manage enrollment count updates', async () => {
+      const groupId = mockCourseGroup._id as string;
+
+      // Get initial state
+      const group = await controller.findOne(groupId);
+      expect(group.currentEnrollments).toBe(15);
+
+      // Update enrollment count
+      const result = await controller.updateEnrollmentCount(groupId);
+      expect(result.message).toBe('Enrollment count updated successfully');
+      expect(service.updateEnrollmentCount).toHaveBeenCalledWith(groupId);
+    });
+  });
+});

--- a/src/test/course-groups.service.spec.ts
+++ b/src/test/course-groups.service.spec.ts
@@ -1,0 +1,697 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { CourseGroupsService } from '../course-groups/services/course-groups.service';
+import {
+  CourseGroup,
+  CourseGroupDocument,
+} from '../course-groups/entities/course-group.entity';
+import { Course, CourseDocument } from '../courses/entities/course.entity';
+import {
+  AcademicPeriod,
+  AcademicPeriodDocument,
+} from '../academic-periods/entities/academic-period.entity';
+import {
+  GroupSchedule,
+  GroupScheduleDocument,
+} from '../group-schedules/entities/group-schedule.entity';
+import {
+  Enrollment,
+  EnrollmentDocument,
+  EnrollmentStatus,
+} from '../enrollments/entities/enrollment.entity';
+
+describe('CourseGroupsService', () => {
+  let service: CourseGroupsService;
+  let courseGroupModel: Model<CourseGroupDocument>;
+  let courseModel: Model<CourseDocument>;
+  let academicPeriodModel: Model<AcademicPeriodDocument>;
+  let groupScheduleModel: Model<GroupScheduleDocument>;
+  let enrollmentModel: Model<EnrollmentDocument>;
+
+  const mockGroupId = '60d5ecb8b0a7c4b4b8b9b1a1';
+  const mockCourseId = '60d5ecb8b0a7c4b4b8b9b1a2';
+  const mockPeriodId = '60d5ecb8b0a7c4b4b8b9b1a3';
+
+  const mockCourse = {
+    _id: mockCourseId,
+    code: 'MAT101',
+    name: 'Matemáticas I',
+    credits: 3,
+  };
+
+  const mockPeriod = {
+    _id: mockPeriodId,
+    code: '2024-2',
+    name: 'Segundo Semestre 2024',
+  };
+
+  const mockGroup = {
+    _id: mockGroupId,
+    courseId: mockCourseId,
+    periodId: mockPeriodId,
+    groupNumber: 'A',
+    maxStudents: 30,
+    currentEnrollments: 15,
+    isActive: true,
+  };
+
+  const mockSchedule = {
+    _id: '60d5ecb8b0a7c4b4b8b9b1a4',
+    groupId: mockGroupId,
+    dayOfWeek: 1,
+    startTime: '08:00',
+    endTime: '10:00',
+    room: 'Aula 101',
+  };
+
+  const mockExecChain = {
+    exec: jest.fn(),
+    populate: jest.fn(),
+  };
+  const mockPopulateChain = {
+    exec: jest.fn(),
+    populate: jest.fn(),
+  };
+
+  // Mock constructor function for courseGroupModel
+  const mockCourseGroupModelConstructor = jest.fn().mockImplementation((data) => ({
+    ...data,
+    _id: mockGroupId,
+    save: jest.fn().mockResolvedValue({
+      _id: mockGroupId,
+      ...data,
+      currentEnrollments: 0,
+    }),
+  }));
+
+  const mockCourseGroupModelValue = Object.assign(mockCourseGroupModelConstructor, {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    findById: jest.fn(),
+    findByIdAndUpdate: jest.fn(),
+    findByIdAndDelete: jest.fn(),
+    updateOne: jest.fn(),
+    create: jest.fn(),
+  });
+
+  beforeEach(async () => {
+    const mockCourseModelValue = {
+      findById: jest.fn(),
+    };
+
+    const mockAcademicPeriodModelValue = {
+      findById: jest.fn(),
+    };
+
+    const mockGroupScheduleModelValue = {
+      find: jest.fn(),
+      deleteMany: jest.fn(),
+    };
+
+    const mockEnrollmentModelValue = {
+      find: jest.fn(),
+      countDocuments: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CourseGroupsService,
+        {
+          provide: getModelToken(CourseGroup.name),
+          useValue: mockCourseGroupModelValue,
+        },
+        {
+          provide: getModelToken(Course.name),
+          useValue: mockCourseModelValue,
+        },
+        {
+          provide: getModelToken(AcademicPeriod.name),
+          useValue: mockAcademicPeriodModelValue,
+        },
+        {
+          provide: getModelToken(GroupSchedule.name),
+          useValue: mockGroupScheduleModelValue,
+        },
+        {
+          provide: getModelToken(Enrollment.name),
+          useValue: mockEnrollmentModelValue,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CourseGroupsService>(CourseGroupsService);
+    courseGroupModel = module.get<Model<CourseGroupDocument>>(
+      getModelToken(CourseGroup.name),
+    );
+    courseModel = module.get<Model<CourseDocument>>(getModelToken(Course.name));
+    academicPeriodModel = module.get<Model<AcademicPeriodDocument>>(
+      getModelToken(AcademicPeriod.name),
+    );
+    groupScheduleModel = module.get<Model<GroupScheduleDocument>>(
+      getModelToken(GroupSchedule.name),
+    );
+    enrollmentModel = module.get<Model<EnrollmentDocument>>(
+      getModelToken(Enrollment.name),
+    );
+
+    mockExecChain.populate.mockReturnValue(mockExecChain);
+    mockPopulateChain.populate.mockReturnValue(mockPopulateChain);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    const createDto = {
+      courseId: mockCourseId,
+      periodId: mockPeriodId,
+      groupNumber: 'A',
+      maxStudents: 30,
+    };
+
+    it('should create a course group successfully', async () => {
+      mockExecChain.exec.mockResolvedValueOnce(mockCourse);
+      (courseModel.findById as jest.Mock).mockReturnValue(mockExecChain);
+
+      mockExecChain.exec.mockResolvedValueOnce(mockPeriod);
+      (academicPeriodModel.findById as jest.Mock).mockReturnValue(mockExecChain);
+
+      mockExecChain.exec.mockResolvedValueOnce(null);
+      (courseGroupModel.findOne as jest.Mock).mockReturnValue(mockExecChain);
+
+      const newGroup = {
+        ...mockGroup,
+        save: jest.fn().mockResolvedValue(mockGroup),
+      };
+      (courseGroupModel.create as jest.Mock) = jest
+        .fn()
+        .mockImplementation(() => newGroup);
+
+      const result = await service.create(createDto);
+
+      expect(courseModel.findById).toHaveBeenCalledWith(mockCourseId);
+      expect(academicPeriodModel.findById).toHaveBeenCalledWith(mockPeriodId);
+      expect(result).toBeDefined();
+    });
+
+    it('should throw NotFoundException when course not found', async () => {
+      mockExecChain.exec.mockResolvedValue(null);
+      (courseModel.findById as jest.Mock).mockReturnValue(mockExecChain);
+
+      await expect(service.create(createDto)).rejects.toThrow(NotFoundException);
+      await expect(service.create(createDto)).rejects.toThrow('Course not found');
+    });
+
+    it('should throw NotFoundException when period not found', async () => {
+      const courseChain = {
+        exec: jest.fn().mockResolvedValue(mockCourse),
+      };
+      const periodChain = {
+        exec: jest.fn().mockResolvedValue(null),
+      };
+      (courseModel.findById as jest.Mock).mockReturnValue(courseChain);
+      (academicPeriodModel.findById as jest.Mock).mockReturnValue(periodChain);
+
+      await expect(service.create(createDto)).rejects.toThrow(NotFoundException);
+      await expect(service.create(createDto)).rejects.toThrow(
+        'Academic period not found',
+      );
+    });
+
+    it('should throw BadRequestException when group already exists', async () => {
+      const courseChain = {
+        exec: jest.fn().mockResolvedValue(mockCourse),
+      };
+      const periodChain = {
+        exec: jest.fn().mockResolvedValue(mockPeriod),
+      };
+      const groupChain = {
+        exec: jest.fn().mockResolvedValue(mockGroup),
+      };
+      (courseModel.findById as jest.Mock).mockReturnValue(courseChain);
+      (academicPeriodModel.findById as jest.Mock).mockReturnValue(periodChain);
+      (courseGroupModel.findOne as jest.Mock).mockReturnValue(groupChain);
+
+      await expect(service.create(createDto)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.create(createDto)).rejects.toThrow(
+        /Group A already exists/,
+      );
+    });
+
+    it('should initialize currentEnrollments to 0', async () => {
+      const courseChain = {
+        exec: jest.fn().mockResolvedValue(mockCourse),
+      };
+      const periodChain = {
+        exec: jest.fn().mockResolvedValue(mockPeriod),
+      };
+      const groupChain = {
+        exec: jest.fn().mockResolvedValue(null),
+      };
+      (courseModel.findById as jest.Mock).mockReturnValue(courseChain);
+      (academicPeriodModel.findById as jest.Mock).mockReturnValue(periodChain);
+      (courseGroupModel.findOne as jest.Mock).mockReturnValue(groupChain);
+
+      await service.create(createDto);
+
+      expect(mockCourseGroupModelConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({ currentEnrollments: 0 }),
+      );
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all course groups with populated data', async () => {
+      const groups = [mockGroup];
+      mockPopulateChain.exec.mockResolvedValue(groups);
+      (courseGroupModel.find as jest.Mock).mockReturnValue(mockPopulateChain);
+
+      const result = await service.findAll();
+
+      expect(courseGroupModel.find).toHaveBeenCalled();
+      expect(mockPopulateChain.populate).toHaveBeenCalledWith('courseId');
+      expect(mockPopulateChain.populate).toHaveBeenCalledWith('periodId');
+      expect(mockPopulateChain.populate).toHaveBeenCalledWith('professorId');
+      expect(result).toEqual(groups);
+    });
+  });
+
+  describe('findByPeriod', () => {
+    it('should return active groups for a period', async () => {
+      const groups = [mockGroup];
+      mockPopulateChain.exec.mockResolvedValue(groups);
+      (courseGroupModel.find as jest.Mock).mockReturnValue(mockPopulateChain);
+
+      const result = await service.findByPeriod(mockPeriodId);
+
+      expect(courseGroupModel.find).toHaveBeenCalledWith({
+        periodId: mockPeriodId,
+        isActive: true,
+      });
+      expect(result).toEqual(groups);
+    });
+  });
+
+  describe('findByCourse', () => {
+    it('should return groups for a course', async () => {
+      const groups = [mockGroup];
+      mockPopulateChain.exec.mockResolvedValue(groups);
+      (courseGroupModel.find as jest.Mock).mockReturnValue(mockPopulateChain);
+
+      const result = await service.findByCourse(mockCourseId);
+
+      expect(courseGroupModel.find).toHaveBeenCalledWith({
+        courseId: mockCourseId,
+        isActive: true,
+      });
+      expect(result).toEqual(groups);
+    });
+
+    it('should filter by period when provided', async () => {
+      const groups = [mockGroup];
+      mockPopulateChain.exec.mockResolvedValue(groups);
+      (courseGroupModel.find as jest.Mock).mockReturnValue(mockPopulateChain);
+
+      await service.findByCourse(mockCourseId, mockPeriodId);
+
+      expect(courseGroupModel.find).toHaveBeenCalledWith({
+        courseId: mockCourseId,
+        periodId: mockPeriodId,
+        isActive: true,
+      });
+    });
+  });
+
+  describe('getAvailableGroups', () => {
+    it('should return groups with available spots', async () => {
+      const groupWithSpots = {
+        ...mockGroup,
+        _id: mockGroupId,
+        courseId: mockCourse,
+      };
+      const findChain = {
+        populate: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([groupWithSpots]),
+      };
+      (courseGroupModel.find as jest.Mock).mockReturnValue(findChain);
+
+      const countChain = {
+        exec: jest.fn().mockResolvedValue(15),
+      };
+      (enrollmentModel.countDocuments as jest.Mock).mockReturnValue(countChain);
+
+      const scheduleChain = {
+        exec: jest.fn().mockResolvedValue([mockSchedule]),
+      };
+      (groupScheduleModel.find as jest.Mock).mockReturnValue(scheduleChain);
+
+      const updateChain = {
+        exec: jest.fn().mockResolvedValue({}),
+      };
+      (courseGroupModel.updateOne as jest.Mock).mockReturnValue(updateChain);
+
+      const result = await service.getAvailableGroups();
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0]).toHaveProperty('availableSpots');
+      expect(result[0].availableSpots).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should exclude full groups', async () => {
+      const fullGroup = {
+        ...mockGroup,
+        _id: mockGroupId,
+        maxStudents: 30,
+        currentEnrollments: 30,
+        courseId: mockCourse,
+      };
+      const findChain = {
+        populate: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([fullGroup]),
+      };
+      (courseGroupModel.find as jest.Mock).mockReturnValue(findChain);
+
+      const countChain = {
+        exec: jest.fn().mockResolvedValue(30),
+      };
+      (enrollmentModel.countDocuments as jest.Mock).mockReturnValue(countChain);
+
+      const updateChain = {
+        exec: jest.fn().mockResolvedValue({}),
+      };
+      (courseGroupModel.updateOne as jest.Mock).mockReturnValue(updateChain);
+
+      const result = await service.getAvailableGroups();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should update enrollment count if different', async () => {
+      const groupWithWrongCount = {
+        ...mockGroup,
+        _id: mockGroupId,
+        courseId: mockCourse,
+        currentEnrollments: 10,
+      };
+      const findChain = {
+        populate: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([groupWithWrongCount]),
+      };
+      (courseGroupModel.find as jest.Mock).mockReturnValue(findChain);
+
+      const countChain = {
+        exec: jest.fn().mockResolvedValue(15),
+      };
+      (enrollmentModel.countDocuments as jest.Mock).mockReturnValue(countChain);
+
+      const scheduleChain = {
+        exec: jest.fn().mockResolvedValue([mockSchedule]),
+      };
+      (groupScheduleModel.find as jest.Mock).mockReturnValue(scheduleChain);
+
+      const updateChain = {
+        exec: jest.fn().mockResolvedValue({}),
+      };
+      (courseGroupModel.updateOne as jest.Mock).mockReturnValue(updateChain);
+
+      await service.getAvailableGroups();
+
+      expect(courseGroupModel.updateOne).toHaveBeenCalledWith(
+        { _id: mockGroupId },
+        { currentEnrollments: 15 },
+      );
+    });
+
+    it('should include schedule information', async () => {
+      const groupWithSpots = {
+        ...mockGroup,
+        _id: mockGroupId,
+        courseId: mockCourse,
+      };
+      const findChain = {
+        populate: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([groupWithSpots]),
+      };
+      (courseGroupModel.find as jest.Mock).mockReturnValue(findChain);
+
+      const countChain = {
+        exec: jest.fn().mockResolvedValue(15),
+      };
+      (enrollmentModel.countDocuments as jest.Mock).mockReturnValue(countChain);
+
+      const scheduleChain = {
+        exec: jest.fn().mockResolvedValue([mockSchedule]),
+      };
+      (groupScheduleModel.find as jest.Mock).mockReturnValue(scheduleChain);
+
+      const updateChain = {
+        exec: jest.fn().mockResolvedValue({}),
+      };
+      (courseGroupModel.updateOne as jest.Mock).mockReturnValue(updateChain);
+
+      const result = await service.getAvailableGroups();
+
+      expect(result[0].schedule).toBeDefined();
+      expect(result[0].schedule.length).toBeGreaterThan(0);
+      expect(result[0].schedule[0]).toHaveProperty('dayOfWeek');
+      expect(result[0].schedule[0]).toHaveProperty('startTime');
+      expect(result[0].schedule[0]).toHaveProperty('endTime');
+    });
+
+    it('should sort schedules by dayOfWeek', async () => {
+      const groupWithSpots = {
+        ...mockGroup,
+        _id: mockGroupId,
+        courseId: mockCourse,
+      };
+      const findChain = {
+        populate: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([groupWithSpots]),
+      };
+      (courseGroupModel.find as jest.Mock).mockReturnValue(findChain);
+
+      const countChain = {
+        exec: jest.fn().mockResolvedValue(15),
+      };
+      (enrollmentModel.countDocuments as jest.Mock).mockReturnValue(countChain);
+
+      const schedules = [
+        { ...mockSchedule, dayOfWeek: 3 },
+        { ...mockSchedule, dayOfWeek: 1 },
+        { ...mockSchedule, dayOfWeek: 2 },
+      ];
+      const scheduleChain = {
+        exec: jest.fn().mockResolvedValue(schedules),
+      };
+      (groupScheduleModel.find as jest.Mock).mockReturnValue(scheduleChain);
+
+      const updateChain = {
+        exec: jest.fn().mockResolvedValue({}),
+      };
+      (courseGroupModel.updateOne as jest.Mock).mockReturnValue(updateChain);
+
+      const result = await service.getAvailableGroups();
+
+      expect(result[0].schedule[0].dayOfWeek).toBe(1);
+      expect(result[0].schedule[1].dayOfWeek).toBe(2);
+      expect(result[0].schedule[2].dayOfWeek).toBe(3);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a group by id', async () => {
+      mockPopulateChain.exec.mockResolvedValue(mockGroup);
+      (courseGroupModel.findById as jest.Mock).mockReturnValue(mockPopulateChain);
+
+      const result = await service.findOne(mockGroupId);
+
+      expect(courseGroupModel.findById).toHaveBeenCalledWith(mockGroupId);
+      expect(result).toEqual(mockGroup);
+    });
+
+    it('should throw NotFoundException when group not found', async () => {
+      mockPopulateChain.exec.mockResolvedValue(null);
+      (courseGroupModel.findById as jest.Mock).mockReturnValue(mockPopulateChain);
+
+      await expect(service.findOne('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.findOne('nonexistent')).rejects.toThrow(
+        'Course group not found',
+      );
+    });
+  });
+
+  describe('update', () => {
+    const updateDto = {
+      maxStudents: 35,
+      isActive: false,
+    };
+
+    it('should update a group successfully', async () => {
+      mockExecChain.exec.mockResolvedValue(mockGroup);
+      (courseGroupModel.findById as jest.Mock).mockReturnValue(mockExecChain);
+
+      const updatedGroup = {
+        ...mockGroup,
+        ...updateDto,
+        save: jest.fn().mockResolvedValue({ ...mockGroup, ...updateDto }),
+      };
+      (courseGroupModel.findById as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(updatedGroup),
+      });
+
+      Object.assign(updatedGroup, updateDto);
+
+      const result = await service.update(mockGroupId, updateDto);
+
+      expect(result.maxStudents).toBe(35);
+      expect(result.isActive).toBe(false);
+    });
+
+    it('should throw NotFoundException when group not found', async () => {
+      mockExecChain.exec.mockResolvedValue(null);
+      (courseGroupModel.findById as jest.Mock).mockReturnValue(mockExecChain);
+
+      await expect(service.update('nonexistent', updateDto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should validate group number uniqueness when updating', async () => {
+      const existingGroup = { ...mockGroup };
+      const anotherGroup = { ...mockGroup, _id: 'different-id' };
+
+      mockExecChain.exec.mockResolvedValueOnce(existingGroup);
+      (courseGroupModel.findById as jest.Mock).mockReturnValue(mockExecChain);
+
+      mockExecChain.exec.mockResolvedValueOnce(anotherGroup);
+      (courseGroupModel.findOne as jest.Mock).mockReturnValue(mockExecChain);
+
+      await expect(
+        service.update(mockGroupId, { groupNumber: 'B' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a group with no enrollments', async () => {
+      mockExecChain.exec.mockResolvedValue(mockGroup);
+      (courseGroupModel.findById as jest.Mock).mockReturnValue(mockExecChain);
+
+      mockExecChain.exec.mockResolvedValue(0);
+      (enrollmentModel.countDocuments as jest.Mock).mockReturnValue(mockExecChain);
+
+      mockExecChain.exec.mockResolvedValue({});
+      (groupScheduleModel.deleteMany as jest.Mock).mockReturnValue(mockExecChain);
+
+      mockExecChain.exec.mockResolvedValue({});
+      (courseGroupModel.findByIdAndDelete as jest.Mock).mockReturnValue(
+        mockExecChain,
+      );
+
+      await service.remove(mockGroupId);
+
+      expect(groupScheduleModel.deleteMany).toHaveBeenCalledWith({
+        groupId: mockGroupId,
+      });
+      expect(courseGroupModel.findByIdAndDelete).toHaveBeenCalledWith(mockGroupId);
+    });
+
+    it('should throw BadRequestException when group has enrollments', async () => {
+      mockExecChain.exec.mockResolvedValue(mockGroup);
+      (courseGroupModel.findById as jest.Mock).mockReturnValue(mockExecChain);
+
+      mockExecChain.exec.mockResolvedValue(5);
+      (enrollmentModel.countDocuments as jest.Mock).mockReturnValue(mockExecChain);
+
+      await expect(service.remove(mockGroupId)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.remove(mockGroupId)).rejects.toThrow(
+        /Cannot delete a group that has enrolled students/,
+      );
+    });
+
+    it('should throw NotFoundException when group not found', async () => {
+      mockExecChain.exec.mockResolvedValue(null);
+      (courseGroupModel.findById as jest.Mock).mockReturnValue(mockExecChain);
+
+      await expect(service.remove('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('updateEnrollmentCount', () => {
+    it('should update enrollment count', async () => {
+      const countChain = {
+        exec: jest.fn().mockResolvedValue(20),
+      };
+      (enrollmentModel.countDocuments as jest.Mock).mockReturnValue(countChain);
+
+      const updateChain = {
+        exec: jest.fn().mockResolvedValue({}),
+      };
+      (courseGroupModel.updateOne as jest.Mock).mockReturnValue(updateChain);
+
+      await service.updateEnrollmentCount(mockGroupId);
+
+      expect(enrollmentModel.countDocuments).toHaveBeenCalledWith({
+        groupId: mockGroupId,
+        status: EnrollmentStatus.ENROLLED,
+      });
+      expect(courseGroupModel.updateOne).toHaveBeenCalledWith(
+        { _id: mockGroupId },
+        { currentEnrollments: 20 },
+      );
+    });
+  });
+
+  describe('getGroupsByStudent', () => {
+    const mockStudentId = 'student123';
+
+    it('should return groups for a student', async () => {
+      const enrollments = [
+        { studentId: mockStudentId, groupId: mockGroupId },
+      ];
+      mockExecChain.exec.mockResolvedValue(enrollments);
+      (enrollmentModel.find as jest.Mock).mockReturnValue(mockExecChain);
+
+      mockPopulateChain.exec.mockResolvedValue([mockGroup]);
+      (courseGroupModel.find as jest.Mock).mockReturnValue(mockPopulateChain);
+
+      const result = await service.getGroupsByStudent(mockStudentId);
+
+      expect(enrollmentModel.find).toHaveBeenCalledWith({
+        studentId: mockStudentId,
+        status: EnrollmentStatus.ENROLLED,
+      });
+      expect(result).toBeDefined();
+    });
+
+    it('should filter by period when provided', async () => {
+      const enrollments = [
+        { studentId: mockStudentId, groupId: mockGroupId },
+      ];
+      mockExecChain.exec.mockResolvedValue(enrollments);
+      (enrollmentModel.find as jest.Mock).mockReturnValue(mockExecChain);
+
+      mockPopulateChain.exec.mockResolvedValue([mockGroup]);
+      (courseGroupModel.find as jest.Mock).mockReturnValue(mockPopulateChain);
+
+      await service.getGroupsByStudent(mockStudentId, mockPeriodId);
+
+      expect(courseGroupModel.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          periodId: mockPeriodId,
+        }),
+      );
+    });
+  });
+});

--- a/src/test/courses.controller.spec.ts
+++ b/src/test/courses.controller.spec.ts
@@ -1,0 +1,176 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CoursesController } from '../courses/courses.controller';
+import { CoursesService } from '../courses/services/courses.service';
+import { CreateCourseDto } from '../courses/dto/create-course.dto';
+import { UpdateCourseDto } from '../courses/dto/update-course.dto';
+
+describe('CoursesController', () => {
+  let controller: CoursesController;
+  let service: CoursesService;
+
+  const mockCoursesService = {
+    create: jest.fn().mockReturnValue('This action adds a new course'),
+    findAll: jest.fn().mockReturnValue(['This action returns all courses']),
+    findOne: jest.fn().mockReturnValue('This action returns a #1 course'),
+    update: jest.fn().mockReturnValue('This action updates a #1 course'),
+    remove: jest.fn().mockReturnValue('This action removes a #1 course'),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CoursesController],
+      providers: [
+        {
+          provide: CoursesService,
+          useValue: mockCoursesService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<CoursesController>(CoursesController);
+    service = module.get<CoursesService>(CoursesService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a new course', () => {
+      const createDto: CreateCourseDto = {} as any;
+      const result = controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledWith(createDto);
+      expect(result).toBe('This action adds a new course');
+    });
+
+    it('should call service create method once', () => {
+      const createDto: CreateCourseDto = {} as any;
+      controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all courses', () => {
+      const result = controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toEqual(['This action returns all courses']);
+    });
+
+    it('should call service findAll method once', () => {
+      controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single course', () => {
+      const id = '1';
+      const result = controller.findOne(id);
+
+      expect(service.findOne).toHaveBeenCalledWith(1);
+      expect(result).toBe('This action returns a #1 course');
+    });
+
+    it('should convert string id to number', () => {
+      const id = '42';
+      controller.findOne(id);
+
+      expect(service.findOne).toHaveBeenCalledWith(42);
+    });
+
+    it('should call service findOne method once', () => {
+      controller.findOne('1');
+
+      expect(service.findOne).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a course', () => {
+      const id = '1';
+      const updateDto: UpdateCourseDto = {} as any;
+      const result = controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(1, updateDto);
+      expect(result).toBe('This action updates a #1 course');
+    });
+
+    it('should convert string id to number', () => {
+      const id = '99';
+      const updateDto: UpdateCourseDto = {} as any;
+      controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(99, updateDto);
+    });
+
+    it('should call service update method once', () => {
+      controller.update('1', {} as any);
+
+      expect(service.update).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a course', () => {
+      const id = '1';
+      const result = controller.remove(id);
+
+      expect(service.remove).toHaveBeenCalledWith(1);
+      expect(result).toBe('This action removes a #1 course');
+    });
+
+    it('should convert string id to number', () => {
+      const id = '123';
+      controller.remove(id);
+
+      expect(service.remove).toHaveBeenCalledWith(123);
+    });
+
+    it('should call service remove method once', () => {
+      controller.remove('1');
+
+      expect(service.remove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Integration: Complete course lifecycle', () => {
+    it('should create, retrieve, update and delete courses', () => {
+      const createDto: CreateCourseDto = {} as any;
+      
+      // Create
+      const created = controller.create(createDto);
+      expect(created).toBeDefined();
+      expect(service.create).toHaveBeenCalledWith(createDto);
+
+      // Find all
+      const all = controller.findAll();
+      expect(all).toBeDefined();
+      expect(service.findAll).toHaveBeenCalled();
+
+      // Find one
+      const one = controller.findOne('1');
+      expect(one).toBeDefined();
+      expect(service.findOne).toHaveBeenCalledWith(1);
+
+      // Update
+      const updateDto: UpdateCourseDto = {} as any;
+      const updated = controller.update('1', updateDto);
+      expect(updated).toBeDefined();
+      expect(service.update).toHaveBeenCalledWith(1, updateDto);
+
+      // Remove
+      const removed = controller.remove('1');
+      expect(removed).toBeDefined();
+      expect(service.remove).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/src/test/custom-validators.spec.ts
+++ b/src/test/custom-validators.spec.ts
@@ -1,0 +1,315 @@
+import {
+  IsStudentCodeConstraint,
+  IsValidNameConstraint,
+  IsStrongPasswordConstraint,
+} from '../common/validators/custom-validators';
+import { ValidationArguments } from 'class-validator';
+
+describe('Custom Validators', () => {
+  const mockValidationArguments: ValidationArguments = {
+    targetName: 'TestClass',
+    property: 'testProperty',
+    object: {},
+    value: '',
+    constraints: [],
+  };
+
+  describe('IsStudentCodeConstraint', () => {
+    let validator: IsStudentCodeConstraint;
+
+    beforeEach(() => {
+      validator = new IsStudentCodeConstraint();
+    });
+
+    describe('validate', () => {
+      it('should accept valid student code with 3 letters and 3 numbers', () => {
+        expect(validator.validate('EST001', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept valid student code with 4 letters and 4 numbers', () => {
+        expect(validator.validate('PROG2024', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept valid student code with 3 letters and 6 numbers', () => {
+        expect(validator.validate('SIS202401', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept valid student code with 4 letters and 6 numbers', () => {
+        expect(validator.validate('MATH123456', mockValidationArguments)).toBe(true);
+      });
+
+      it('should reject code with lowercase letters', () => {
+        expect(validator.validate('est001', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject code with mixed case letters', () => {
+        expect(validator.validate('Est001', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject code with only 2 letters', () => {
+        expect(validator.validate('ES001', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject code with 5 letters', () => {
+        expect(validator.validate('ESTUD001', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject code with only 2 numbers', () => {
+        expect(validator.validate('EST01', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject code with 7 numbers', () => {
+        expect(validator.validate('EST1234567', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject code with special characters', () => {
+        expect(validator.validate('EST-001', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject code with spaces', () => {
+        expect(validator.validate('EST 001', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject empty string', () => {
+        expect(validator.validate('', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject null', () => {
+        expect(validator.validate(null as any, mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject undefined', () => {
+        expect(validator.validate(undefined as any, mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject code with letters after numbers', () => {
+        expect(validator.validate('001EST', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject code with mixed letters and numbers', () => {
+        expect(validator.validate('E1S2T3', mockValidationArguments)).toBe(false);
+      });
+    });
+
+    describe('defaultMessage', () => {
+      it('should return appropriate error message', () => {
+        const message = validator.defaultMessage(mockValidationArguments);
+        expect(message).toContain('3-4 letras');
+        expect(message).toContain('3-6 números');
+      });
+    });
+  });
+
+  describe('IsValidNameConstraint', () => {
+    let validator: IsValidNameConstraint;
+
+    beforeEach(() => {
+      validator = new IsValidNameConstraint();
+    });
+
+    describe('validate', () => {
+      it('should accept simple name', () => {
+        expect(validator.validate('Juan', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept name with multiple words', () => {
+        expect(validator.validate('Juan Carlos', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept name with accents', () => {
+        expect(validator.validate('José María', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept name with ñ', () => {
+        expect(validator.validate('Niño', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept name with Ñ', () => {
+        expect(validator.validate('NIÑO', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept name with ü', () => {
+        expect(validator.validate('Güemes', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept name with all Spanish accents', () => {
+        expect(validator.validate('Áéíóú', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept name with uppercase accents', () => {
+        expect(validator.validate('ÁÉÍÓÚ', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept name with leading/trailing spaces', () => {
+        expect(validator.validate('  Juan  ', mockValidationArguments)).toBe(true);
+      });
+
+      it('should reject name with numbers', () => {
+        expect(validator.validate('Juan123', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject name with special characters', () => {
+        expect(validator.validate('Juan@', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject name with hyphens', () => {
+        expect(validator.validate('Juan-Carlos', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject name with underscores', () => {
+        expect(validator.validate('Juan_Carlos', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject name with dots', () => {
+        expect(validator.validate('Juan.Carlos', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject empty string', () => {
+        expect(validator.validate('', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject null', () => {
+        expect(validator.validate(null as any, mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject undefined', () => {
+        expect(validator.validate(undefined as any, mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject whitespace-only string', () => {
+        expect(validator.validate('   ', mockValidationArguments)).toBe(false);
+      });
+    });
+
+    describe('defaultMessage', () => {
+      it('should return appropriate error message', () => {
+        const message = validator.defaultMessage(mockValidationArguments);
+        expect(message).toContain('letras');
+        expect(message).toContain('espacios');
+        expect(message).toContain('acentos');
+      });
+    });
+  });
+
+  describe('IsStrongPasswordConstraint', () => {
+    let validator: IsStrongPasswordConstraint;
+
+    beforeEach(() => {
+      validator = new IsStrongPasswordConstraint();
+    });
+
+    describe('validate', () => {
+      it('should accept strong password with minimum requirements', () => {
+        expect(validator.validate('Password1', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept password with special characters', () => {
+        expect(validator.validate('Pass@word1', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept password with multiple special characters', () => {
+        expect(validator.validate('P@ssw0rd!', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept long password', () => {
+        expect(validator.validate('VeryLongPassword123', mockValidationArguments)).toBe(true);
+      });
+
+      it('should accept password with all allowed special chars', () => {
+        expect(validator.validate('P@ssw0rd$!%*?&', mockValidationArguments)).toBe(true);
+      });
+
+      it('should reject password shorter than 8 characters', () => {
+        expect(validator.validate('Pass1', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject password exactly 7 characters', () => {
+        expect(validator.validate('Pass123', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject password without uppercase', () => {
+        expect(validator.validate('password1', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject password without lowercase', () => {
+        expect(validator.validate('PASSWORD1', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject password without numbers', () => {
+        expect(validator.validate('Password', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject password with only uppercase and numbers', () => {
+        expect(validator.validate('PASSWORD123', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject password with only lowercase and numbers', () => {
+        expect(validator.validate('password123', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject password with only letters', () => {
+        expect(validator.validate('PasswordOnly', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject empty string', () => {
+        expect(validator.validate('', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject null', () => {
+        expect(validator.validate(null as any, mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject undefined', () => {
+        expect(validator.validate(undefined as any, mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject password with spaces', () => {
+        expect(validator.validate('Pass word1', mockValidationArguments)).toBe(false);
+      });
+
+      it('should reject password with invalid special characters', () => {
+        expect(validator.validate('Password1#', mockValidationArguments)).toBe(false);
+      });
+
+      it('should accept password exactly 8 characters', () => {
+        expect(validator.validate('Passw0rd', mockValidationArguments)).toBe(true);
+      });
+    });
+
+    describe('defaultMessage', () => {
+      it('should return appropriate error message', () => {
+        const message = validator.defaultMessage(mockValidationArguments);
+        expect(message).toContain('8 caracteres');
+        expect(message).toContain('mayúscula');
+        expect(message).toContain('minúscula');
+        expect(message).toContain('número');
+      });
+    });
+  });
+
+  describe('Integration: Multiple validators', () => {
+    it('should validate student data with multiple validators', () => {
+      const studentCodeValidator = new IsStudentCodeConstraint();
+      const nameValidator = new IsValidNameConstraint();
+
+      const studentCode = 'EST2024';
+      const firstName = 'Juan Carlos';
+      const lastName = 'García';
+
+      expect(studentCodeValidator.validate(studentCode, mockValidationArguments)).toBe(true);
+      expect(nameValidator.validate(firstName, mockValidationArguments)).toBe(true);
+      expect(nameValidator.validate(lastName, mockValidationArguments)).toBe(true);
+    });
+
+    it('should reject invalid student data', () => {
+      const studentCodeValidator = new IsStudentCodeConstraint();
+      const nameValidator = new IsValidNameConstraint();
+
+      const invalidCode = 'est2024'; // lowercase
+      const invalidName = 'Juan123'; // with numbers
+
+      expect(studentCodeValidator.validate(invalidCode, mockValidationArguments)).toBe(false);
+      expect(nameValidator.validate(invalidName, mockValidationArguments)).toBe(false);
+    });
+  });
+});

--- a/src/test/enrollments.controller.spec.ts
+++ b/src/test/enrollments.controller.spec.ts
@@ -1,0 +1,250 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EnrollmentsController } from '../enrollments/enrollments.controller';
+import { EnrollmentsService } from '../enrollments/services/enrollments.service';
+import { CreateEnrollmentDto } from '../enrollments/dto/create-enrollment.dto';
+import { UpdateEnrollmentDto } from '../enrollments/dto/update-enrollment.dto';
+import { EnrollmentStatus } from '../enrollments/entities/enrollment.entity';
+
+describe('EnrollmentsController', () => {
+  let controller: EnrollmentsController;
+  let service: EnrollmentsService;
+
+  const mockEnrollment = {
+    _id: '60d5ecb8b0a7c4b4b8b9b1a4',
+    studentId: 'STU001',
+    groupId: 'GROUP001',
+    status: EnrollmentStatus.ENROLLED,
+    enrolledAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EnrollmentsController],
+      providers: [
+        {
+          provide: EnrollmentsService,
+          useValue: {
+            create: jest.fn().mockResolvedValue(mockEnrollment),
+            enrollStudentInCourse: jest.fn().mockResolvedValue(mockEnrollment),
+            findAll: jest.fn().mockResolvedValue([mockEnrollment]),
+            findByStudent: jest.fn().mockResolvedValue([mockEnrollment]),
+            findOne: jest.fn().mockResolvedValue(mockEnrollment),
+            update: jest
+              .fn()
+              .mockResolvedValue({ ...mockEnrollment, status: EnrollmentStatus.PASSED }),
+            remove: jest.fn().mockResolvedValue({ deleted: true }),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<EnrollmentsController>(EnrollmentsController);
+    service = module.get<EnrollmentsService>(EnrollmentsService);
+  });
+
+  describe('create', () => {
+    it('should create an enrollment', async () => {
+      const createDto: CreateEnrollmentDto = {
+        studentId: 'STU001',
+        groupId: 'GROUP001',
+      };
+
+      const result = await controller.create(createDto);
+
+      expect(result).toEqual(mockEnrollment);
+      expect(service.create).toHaveBeenCalledWith(createDto);
+    });
+
+    it('should call service with correct dto', async () => {
+      const createDto: CreateEnrollmentDto = {
+        studentId: 'STU002',
+        groupId: 'GROUP002',
+      };
+
+      await controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledWith(createDto);
+      expect(service.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('enrollStudent', () => {
+    it('should enroll a student in a course group', async () => {
+      const studentCode = 'STU001';
+      const groupId = 'GROUP001';
+
+      const result = await controller.enrollStudent(studentCode, groupId);
+
+      expect(result).toEqual(mockEnrollment);
+      expect(service.enrollStudentInCourse).toHaveBeenCalledWith(studentCode, groupId);
+    });
+
+    it('should handle different student codes', async () => {
+      await controller.enrollStudent('STU001', 'GROUP001');
+      await controller.enrollStudent('STU002', 'GROUP002');
+
+      expect(service.enrollStudentInCourse).toHaveBeenCalledTimes(2);
+      expect(service.enrollStudentInCourse).toHaveBeenNthCalledWith(1, 'STU001', 'GROUP001');
+      expect(service.enrollStudentInCourse).toHaveBeenNthCalledWith(2, 'STU002', 'GROUP002');
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all enrollments', async () => {
+      const result = await controller.findAll();
+
+      expect(result).toEqual([mockEnrollment]);
+      expect(service.findAll).toHaveBeenCalled();
+    });
+
+    it('should call service findAll', async () => {
+      await controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findByStudent', () => {
+    it('should return enrollments for a specific student', async () => {
+      const studentCode = 'STU001';
+
+      const result = await controller.findByStudent(studentCode);
+
+      expect(result).toEqual([mockEnrollment]);
+      expect(service.findByStudent).toHaveBeenCalledWith(studentCode);
+    });
+
+    it('should handle different student codes', async () => {
+      await controller.findByStudent('STU001');
+      await controller.findByStudent('STU002');
+
+      expect(service.findByStudent).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single enrollment by id', async () => {
+      const enrollmentId = '60d5ecb8b0a7c4b4b8b9b1a4';
+
+      const result = await controller.findOne(enrollmentId);
+
+      expect(result).toEqual(mockEnrollment);
+      expect(service.findOne).toHaveBeenCalledWith(enrollmentId);
+    });
+
+    it('should call service with correct id', async () => {
+      const enrollmentId = 'test-id-123';
+
+      await controller.findOne(enrollmentId);
+
+      expect(service.findOne).toHaveBeenCalledWith(enrollmentId);
+    });
+  });
+
+  describe('update', () => {
+    it('should update an enrollment', async () => {
+      const enrollmentId = '60d5ecb8b0a7c4b4b8b9b1a4';
+      const updateDto: UpdateEnrollmentDto = {
+        status: EnrollmentStatus.PASSED,
+      };
+
+      const result = await controller.update(enrollmentId, updateDto);
+
+      expect(result).toHaveProperty('status', EnrollmentStatus.PASSED);
+      expect(service.update).toHaveBeenCalledWith(enrollmentId, updateDto);
+    });
+
+    it('should handle partial updates', async () => {
+      const enrollmentId = '60d5ecb8b0a7c4b4b8b9b1a4';
+      const updateDto: UpdateEnrollmentDto = {};
+
+      await controller.update(enrollmentId, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(enrollmentId, updateDto);
+    });
+
+    it('should return updated enrollment', async () => {
+      const enrollmentId = '60d5ecb8b0a7c4b4b8b9b1a4';
+      const updateDto: UpdateEnrollmentDto = {
+        status: EnrollmentStatus.PASSED,
+      };
+
+      const result = await controller.update(enrollmentId, updateDto);
+
+      expect(result).toHaveProperty('_id', enrollmentId);
+      expect(result).toHaveProperty('status', EnrollmentStatus.PASSED);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove an enrollment', async () => {
+      const enrollmentId = '60d5ecb8b0a7c4b4b8b9b1a4';
+
+      const result = await controller.remove(enrollmentId);
+
+      expect(result).toEqual({ deleted: true });
+      expect(service.remove).toHaveBeenCalledWith(enrollmentId);
+    });
+
+    it('should call service remove with correct id', async () => {
+      const enrollmentId = 'test-id-456';
+
+      await controller.remove(enrollmentId);
+
+      expect(service.remove).toHaveBeenCalledWith(enrollmentId);
+      expect(service.remove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Integration scenarios', () => {
+    it('should handle complete enrollment lifecycle', async () => {
+      // Create
+      const createDto: CreateEnrollmentDto = {
+        studentId: 'STU001',
+        groupId: 'GROUP001',
+      };
+      const created = await controller.create(createDto);
+      expect(created).toBeDefined();
+
+      // Find
+      const found = await controller.findOne(mockEnrollment._id);
+      expect(found).toBeDefined();
+
+      // Update
+      const updated = await controller.update(mockEnrollment._id, {
+        status: EnrollmentStatus.PASSED,
+      });
+      expect(updated.status).toBe(EnrollmentStatus.PASSED);
+
+      // Remove
+      const removed = await controller.remove(mockEnrollment._id);
+      expect(removed).toHaveProperty('deleted', true);
+    });
+
+    it('should handle student enrollment workflow', async () => {
+      const studentCode = 'STU001';
+
+      // Enroll in course
+      const enrollment = await controller.enrollStudent(studentCode, 'GROUP001');
+      expect(enrollment.studentId).toBeDefined();
+
+      // Get student enrollments
+      const enrollments = await controller.findByStudent(studentCode);
+      expect(Array.isArray(enrollments)).toBe(true);
+    });
+
+    it('should handle multiple operations', async () => {
+      // Create multiple
+      await controller.create({ studentId: 'STU001', groupId: 'GROUP001' });
+      await controller.create({ studentId: 'STU002', groupId: 'GROUP002' });
+
+      // Find all
+      const all = await controller.findAll();
+      expect(Array.isArray(all)).toBe(true);
+
+      // Verify service calls
+      expect(service.create).toHaveBeenCalledTimes(2);
+      expect(service.findAll).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/test/enrollments.service.spec.ts
+++ b/src/test/enrollments.service.spec.ts
@@ -1,0 +1,507 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { EnrollmentsService } from '../enrollments/services/enrollments.service';
+import {
+  Enrollment,
+  EnrollmentDocument,
+  EnrollmentStatus,
+} from '../enrollments/entities/enrollment.entity';
+import { Student, StudentDocument } from '../students/entities/student.entity';
+import {
+  CourseGroup,
+  CourseGroupDocument,
+} from '../course-groups/entities/course-group.entity';
+
+describe('EnrollmentsService', () => {
+  let service: EnrollmentsService;
+  let enrollmentModel: Model<EnrollmentDocument>;
+  let studentModel: Model<StudentDocument>;
+  let courseGroupModel: Model<CourseGroupDocument>;
+
+  const mockStudentId = '60d5ecb8b0a7c4b4b8b9b1a1';
+  const mockGroupId = '60d5ecb8b0a7c4b4b8b9b1a2';
+  const mockEnrollmentId = '60d5ecb8b0a7c4b4b8b9b1a3';
+
+  const mockStudent = {
+    _id: mockStudentId,
+    code: 'STU001',
+    firstName: 'Juan',
+    lastName: 'Pérez',
+    externalId: 'student123',
+  };
+
+  const mockCourse = {
+    _id: '60d5ecb8b0a7c4b4b8b9b1a4',
+    code: 'MAT101',
+    name: 'Matemáticas I',
+    credits: 3,
+  };
+
+  const mockGroup = {
+    _id: mockGroupId,
+    courseId: mockCourse,
+    groupNumber: 'A',
+    maxStudents: 30,
+    currentEnrollments: 15,
+  };
+
+  const mockEnrollment = {
+    _id: mockEnrollmentId,
+    studentId: mockStudentId,
+    groupId: mockGroupId,
+    status: EnrollmentStatus.ENROLLED,
+    enrolledAt: new Date(),
+    save: jest.fn().mockResolvedValue(this),
+  };
+
+  // Mock constructor function for enrollmentModel
+  const mockEnrollmentModelConstructor = jest.fn().mockImplementation((data) => ({
+    ...data,
+    _id: mockEnrollmentId,
+    save: jest.fn().mockResolvedValue({
+      _id: mockEnrollmentId,
+      ...data,
+    }),
+  }));
+
+  const mockEnrollmentModel = Object.assign(mockEnrollmentModelConstructor, {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    findById: jest.fn(),
+    findByIdAndUpdate: jest.fn(),
+    findByIdAndDelete: jest.fn(),
+    countDocuments: jest.fn(),
+    create: jest.fn(),
+  });
+
+  const mockStudentModel = {
+    findOne: jest.fn(),
+  };
+
+  const mockCourseGroupModel = {
+    findById: jest.fn(),
+  };
+
+  const mockPopulateChain = {
+    exec: jest.fn(),
+    populate: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EnrollmentsService,
+        {
+          provide: getModelToken(Enrollment.name),
+          useValue: mockEnrollmentModel,
+        },
+        {
+          provide: getModelToken(Student.name),
+          useValue: mockStudentModel,
+        },
+        {
+          provide: getModelToken(CourseGroup.name),
+          useValue: mockCourseGroupModel,
+        },
+      ],
+    }).compile();
+
+    service = module.get<EnrollmentsService>(EnrollmentsService);
+    enrollmentModel = module.get<Model<EnrollmentDocument>>(
+      getModelToken(Enrollment.name),
+    );
+    studentModel = module.get<Model<StudentDocument>>(
+      getModelToken(Student.name),
+    );
+    courseGroupModel = module.get<Model<CourseGroupDocument>>(
+      getModelToken(CourseGroup.name),
+    );
+
+    // Configure populate chain
+    mockPopulateChain.populate.mockReturnValue(mockPopulateChain);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    const createEnrollmentDto = {
+      studentId: 'STU001',
+      groupId: mockGroupId,
+      status: EnrollmentStatus.ENROLLED,
+    };
+
+    it('should create an enrollment successfully', async () => {
+      mockStudentModel.findOne.mockResolvedValue(mockStudent);
+      mockPopulateChain.exec.mockResolvedValue(mockGroup);
+      mockCourseGroupModel.findById.mockReturnValue(mockPopulateChain);
+      mockEnrollmentModel.findOne.mockResolvedValue(null);
+
+      const newEnrollment = {
+        ...mockEnrollment,
+        save: jest.fn().mockResolvedValue(mockEnrollment),
+      };
+      mockEnrollmentModel.create = jest.fn().mockImplementation(() => newEnrollment);
+
+      const result = await service.create(createEnrollmentDto);
+
+      expect(mockStudentModel.findOne).toHaveBeenCalledWith({ code: 'STU001' });
+      expect(mockCourseGroupModel.findById).toHaveBeenCalledWith(mockGroupId);
+      expect(mockEnrollmentModel.findOne).toHaveBeenCalled();
+      expect(result).toBeDefined();
+    });
+
+    it('should throw NotFoundException when student does not exist', async () => {
+      mockStudentModel.findOne.mockResolvedValue(null);
+
+      await expect(service.create(createEnrollmentDto)).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.create(createEnrollmentDto)).rejects.toThrow(
+        'Student with ID STU001 not found',
+      );
+    });
+
+    it('should throw NotFoundException when course group does not exist', async () => {
+      mockStudentModel.findOne.mockResolvedValue(mockStudent);
+      const populateChain = {
+        populate: jest.fn().mockResolvedValue(null),
+      };
+      mockCourseGroupModel.findById.mockReturnValue(populateChain);
+
+      await expect(service.create(createEnrollmentDto)).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.create(createEnrollmentDto)).rejects.toThrow(
+        `Course group with ID ${mockGroupId} not found`,
+      );
+    });
+
+    it('should throw BadRequestException when student is already enrolled', async () => {
+      mockStudentModel.findOne.mockResolvedValue(mockStudent);
+      mockPopulateChain.exec.mockResolvedValue(mockGroup);
+      mockCourseGroupModel.findById.mockReturnValue(mockPopulateChain);
+      mockEnrollmentModel.findOne.mockResolvedValue(mockEnrollment);
+
+      await expect(service.create(createEnrollmentDto)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.create(createEnrollmentDto)).rejects.toThrow(
+        'Student is already enrolled in this course group',
+      );
+    });
+
+    it('should not allow duplicate enrollment with PASSED status', async () => {
+      mockStudentModel.findOne.mockResolvedValue(mockStudent);
+      mockPopulateChain.exec.mockResolvedValue(mockGroup);
+      mockCourseGroupModel.findById.mockReturnValue(mockPopulateChain);
+      mockEnrollmentModel.findOne.mockResolvedValue({
+        ...mockEnrollment,
+        status: EnrollmentStatus.PASSED,
+      });
+
+      await expect(service.create(createEnrollmentDto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should set default status to ENROLLED when not provided', async () => {
+      const dtoWithoutStatus = {
+        studentId: 'STU001',
+        groupId: mockGroupId,
+      };
+
+      mockStudentModel.findOne.mockResolvedValue(mockStudent);
+      mockPopulateChain.exec.mockResolvedValue(mockGroup);
+      mockCourseGroupModel.findById.mockReturnValue(mockPopulateChain);
+      mockEnrollmentModel.findOne.mockResolvedValue(null);
+
+      await service.create(dtoWithoutStatus);
+
+      expect(mockEnrollmentModelConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: EnrollmentStatus.ENROLLED,
+        }),
+      );
+    });
+
+    it('should include enrolledAt timestamp', async () => {
+      mockStudentModel.findOne.mockResolvedValue(mockStudent);
+      mockPopulateChain.exec.mockResolvedValue(mockGroup);
+      mockCourseGroupModel.findById.mockReturnValue(mockPopulateChain);
+      mockEnrollmentModel.findOne.mockResolvedValue(null);
+
+      await service.create(createEnrollmentDto);
+
+      expect(mockEnrollmentModelConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enrolledAt: expect.any(Date),
+        }),
+      );
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all enrollments with populated data', async () => {
+      const enrollments = [mockEnrollment];
+      mockPopulateChain.exec.mockResolvedValue(enrollments);
+      mockEnrollmentModel.find.mockReturnValue(mockPopulateChain);
+
+      const result = await service.findAll();
+
+      expect(mockEnrollmentModel.find).toHaveBeenCalled();
+      expect(mockPopulateChain.populate).toHaveBeenCalledWith('studentId');
+      expect(result).toEqual(enrollments);
+    });
+
+    it('should return empty array when no enrollments exist', async () => {
+      mockPopulateChain.exec.mockResolvedValue([]);
+      mockEnrollmentModel.find.mockReturnValue(mockPopulateChain);
+
+      const result = await service.findAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return an enrollment by id', async () => {
+      mockPopulateChain.exec.mockResolvedValue(mockEnrollment);
+      mockEnrollmentModel.findById.mockReturnValue(mockPopulateChain);
+
+      const result = await service.findOne(mockEnrollmentId);
+
+      expect(mockEnrollmentModel.findById).toHaveBeenCalledWith(mockEnrollmentId);
+      expect(result).toEqual(mockEnrollment);
+    });
+
+    it('should throw NotFoundException when enrollment not found', async () => {
+      mockPopulateChain.exec.mockResolvedValue(null);
+      mockEnrollmentModel.findById.mockReturnValue(mockPopulateChain);
+
+      await expect(service.findOne('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.findOne('nonexistent')).rejects.toThrow(
+        'Enrollment with ID nonexistent not found',
+      );
+    });
+  });
+
+  describe('findByStudent', () => {
+    it('should return all enrollments for a student', async () => {
+      const enrollments = [mockEnrollment];
+      mockStudentModel.findOne.mockResolvedValue(mockStudent);
+      mockPopulateChain.exec.mockResolvedValue(enrollments);
+      mockEnrollmentModel.find.mockReturnValue(mockPopulateChain);
+
+      const result = await service.findByStudent('STU001');
+
+      expect(mockStudentModel.findOne).toHaveBeenCalledWith({ code: 'STU001' });
+      expect(mockEnrollmentModel.find).toHaveBeenCalledWith({
+        studentId: mockStudentId,
+      });
+      expect(result).toEqual(enrollments);
+    });
+
+    it('should throw NotFoundException when student not found', async () => {
+      mockStudentModel.findOne.mockResolvedValue(null);
+
+      await expect(service.findByStudent('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.findByStudent('nonexistent')).rejects.toThrow(
+        'Student with code nonexistent not found',
+      );
+    });
+
+    it('should return empty array when student has no enrollments', async () => {
+      mockStudentModel.findOne.mockResolvedValue(mockStudent);
+      mockPopulateChain.exec.mockResolvedValue([]);
+      mockEnrollmentModel.find.mockReturnValue(mockPopulateChain);
+
+      const result = await service.findByStudent('STU001');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('update', () => {
+    const updateDto = {
+      status: EnrollmentStatus.PASSED,
+      grade: 4.5,
+    };
+
+    it('should update an enrollment successfully', async () => {
+      const updatedEnrollment = { ...mockEnrollment, ...updateDto };
+      mockEnrollmentModel.findByIdAndUpdate.mockResolvedValue(updatedEnrollment);
+
+      const result = await service.update(mockEnrollmentId, updateDto);
+
+      expect(mockEnrollmentModel.findByIdAndUpdate).toHaveBeenCalledWith(
+        mockEnrollmentId,
+        updateDto,
+        { new: true },
+      );
+      expect(result.status).toBe(EnrollmentStatus.PASSED);
+      expect(result.grade).toBe(4.5);
+    });
+
+    it('should throw NotFoundException when enrollment not found', async () => {
+      mockEnrollmentModel.findByIdAndUpdate.mockResolvedValue(null);
+
+      await expect(service.update('nonexistent', updateDto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should allow updating only grade', async () => {
+      const gradeUpdateDto = { grade: 3.5 };
+      const updatedEnrollment = { ...mockEnrollment, grade: 3.5 };
+      mockEnrollmentModel.findByIdAndUpdate.mockResolvedValue(updatedEnrollment);
+
+      const result = await service.update(mockEnrollmentId, gradeUpdateDto);
+
+      expect(result.grade).toBe(3.5);
+    });
+
+    it('should allow updating only status', async () => {
+      const statusUpdateDto = { status: EnrollmentStatus.FAILED };
+      const updatedEnrollment = {
+        ...mockEnrollment,
+        status: EnrollmentStatus.FAILED,
+      };
+      mockEnrollmentModel.findByIdAndUpdate.mockResolvedValue(updatedEnrollment);
+
+      const result = await service.update(mockEnrollmentId, statusUpdateDto);
+
+      expect(result.status).toBe(EnrollmentStatus.FAILED);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove an enrollment successfully', async () => {
+      mockEnrollmentModel.findByIdAndDelete.mockResolvedValue(mockEnrollment);
+
+      await service.remove(mockEnrollmentId);
+
+      expect(mockEnrollmentModel.findByIdAndDelete).toHaveBeenCalledWith(
+        mockEnrollmentId,
+      );
+    });
+
+    it('should throw NotFoundException when enrollment not found', async () => {
+      mockEnrollmentModel.findByIdAndDelete.mockResolvedValue(null);
+
+      await expect(service.remove('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.remove('nonexistent')).rejects.toThrow(
+        'Enrollment with ID nonexistent not found',
+      );
+    });
+  });
+
+  describe('enrollStudentInCourse', () => {
+    it('should enroll student using helper method', async () => {
+      mockStudentModel.findOne.mockResolvedValue(mockStudent);
+      mockPopulateChain.exec.mockResolvedValue(mockGroup);
+      mockCourseGroupModel.findById.mockReturnValue(mockPopulateChain);
+      mockEnrollmentModel.findOne.mockResolvedValue(null);
+
+      const result = await service.enrollStudentInCourse('STU001', mockGroupId);
+
+      expect(result).toBeDefined();
+      expect(mockEnrollmentModelConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: EnrollmentStatus.ENROLLED,
+        }),
+      );
+    });
+
+    it('should throw error if student already enrolled', async () => {
+      mockStudentModel.findOne.mockResolvedValue(mockStudent);
+      mockPopulateChain.exec.mockResolvedValue(mockGroup);
+      mockCourseGroupModel.findById.mockReturnValue(mockPopulateChain);
+      mockEnrollmentModel.findOne.mockResolvedValue(mockEnrollment);
+
+      await expect(
+        service.enrollStudentInCourse('STU001', mockGroupId),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('Edge cases and validation', () => {
+    it('should handle concurrent enrollment attempts', async () => {
+      mockStudentModel.findOne.mockResolvedValue(mockStudent);
+      mockPopulateChain.exec.mockResolvedValue(mockGroup);
+      mockCourseGroupModel.findById.mockReturnValue(mockPopulateChain);
+      mockEnrollmentModel.findOne.mockResolvedValue(null);
+
+      const enrollmentPromises = [
+        service.create({ studentId: 'STU001', groupId: mockGroupId }),
+        service.create({ studentId: 'STU001', groupId: mockGroupId }),
+      ];
+
+      // Both should attempt to create
+      await Promise.all(enrollmentPromises.map((p) => p.catch((e) => e)));
+
+      expect(mockEnrollmentModelConstructor).toHaveBeenCalled();
+    });
+
+    it('should properly populate course data in group', async () => {
+      const enrollments = [
+        {
+          ...mockEnrollment,
+          groupId: mockGroup,
+        },
+      ];
+      mockPopulateChain.exec.mockResolvedValue(enrollments);
+      mockEnrollmentModel.find.mockReturnValue(mockPopulateChain);
+
+      await service.findAll();
+
+      expect(mockPopulateChain.populate).toHaveBeenCalledWith('studentId');
+      expect(mockPopulateChain.populate).toHaveBeenCalledWith({
+        path: 'groupId',
+        populate: { path: 'courseId' },
+      });
+    });
+
+    it('should handle enrollment with null grade', async () => {
+      const enrollmentWithNullGrade = { ...mockEnrollment, grade: null };
+      mockEnrollmentModel.findByIdAndUpdate.mockResolvedValue(
+        enrollmentWithNullGrade,
+      );
+
+      const result = await service.update(mockEnrollmentId, { grade: undefined });
+
+      expect(result.grade).toBeNull();
+    });
+
+    it('should check for ENROLLED and PASSED status in duplicate check', async () => {
+      mockStudentModel.findOne.mockResolvedValue(mockStudent);
+      mockPopulateChain.exec.mockResolvedValue(mockGroup);
+      mockCourseGroupModel.findById.mockReturnValue(mockPopulateChain);
+      mockEnrollmentModel.findOne.mockImplementation((query) => {
+        // Verify the status query includes both ENROLLED and PASSED
+        expect(query.status.$in).toContain(EnrollmentStatus.ENROLLED);
+        expect(query.status.$in).toContain(EnrollmentStatus.PASSED);
+        return Promise.resolve(null);
+      });
+
+      const newEnrollment = {
+        ...mockEnrollment,
+        save: jest.fn().mockResolvedValue(mockEnrollment),
+      };
+      mockEnrollmentModel.create = jest.fn().mockImplementation(() => newEnrollment);
+
+      await service.create({ studentId: 'STU001', groupId: mockGroupId });
+
+      expect(mockEnrollmentModel.findOne).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/test/faculty.controller.spec.ts
+++ b/src/test/faculty.controller.spec.ts
@@ -1,0 +1,176 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FacultyController } from '../faculty/faculty.controller';
+import { FacultyService } from '../faculty/services/faculty.service';
+import { CreateFacultyDto } from '../faculty/dto/create-faculty.dto';
+import { UpdateFacultyDto } from '../faculty/dto/update-faculty.dto';
+
+describe('FacultyController', () => {
+  let controller: FacultyController;
+  let service: FacultyService;
+
+  const mockFacultyService = {
+    create: jest.fn().mockReturnValue('This action adds a new faculty'),
+    findAll: jest.fn().mockReturnValue(['This action returns all faculty']),
+    findOne: jest.fn().mockReturnValue('This action returns a #1 faculty'),
+    update: jest.fn().mockReturnValue('This action updates a #1 faculty'),
+    remove: jest.fn().mockReturnValue('This action removes a #1 faculty'),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FacultyController],
+      providers: [
+        {
+          provide: FacultyService,
+          useValue: mockFacultyService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<FacultyController>(FacultyController);
+    service = module.get<FacultyService>(FacultyService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a new faculty', () => {
+      const createDto: CreateFacultyDto = {} as any;
+      const result = controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledWith(createDto);
+      expect(result).toBe('This action adds a new faculty');
+    });
+
+    it('should call service create method once', () => {
+      const createDto: CreateFacultyDto = {} as any;
+      controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all faculties', () => {
+      const result = controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toEqual(['This action returns all faculty']);
+    });
+
+    it('should call service findAll method once', () => {
+      controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single faculty', () => {
+      const id = '1';
+      const result = controller.findOne(id);
+
+      expect(service.findOne).toHaveBeenCalledWith(1);
+      expect(result).toBe('This action returns a #1 faculty');
+    });
+
+    it('should convert string id to number', () => {
+      const id = '42';
+      controller.findOne(id);
+
+      expect(service.findOne).toHaveBeenCalledWith(42);
+    });
+
+    it('should call service findOne method once', () => {
+      controller.findOne('1');
+
+      expect(service.findOne).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a faculty', () => {
+      const id = '1';
+      const updateDto: UpdateFacultyDto = {} as any;
+      const result = controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(1, updateDto);
+      expect(result).toBe('This action updates a #1 faculty');
+    });
+
+    it('should convert string id to number', () => {
+      const id = '99';
+      const updateDto: UpdateFacultyDto = {} as any;
+      controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(99, updateDto);
+    });
+
+    it('should call service update method once', () => {
+      controller.update('1', {} as any);
+
+      expect(service.update).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a faculty', () => {
+      const id = '1';
+      const result = controller.remove(id);
+
+      expect(service.remove).toHaveBeenCalledWith(1);
+      expect(result).toBe('This action removes a #1 faculty');
+    });
+
+    it('should convert string id to number', () => {
+      const id = '123';
+      controller.remove(id);
+
+      expect(service.remove).toHaveBeenCalledWith(123);
+    });
+
+    it('should call service remove method once', () => {
+      controller.remove('1');
+
+      expect(service.remove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Integration: Complete faculty lifecycle', () => {
+    it('should create, retrieve, update and delete faculties', () => {
+      const createDto: CreateFacultyDto = {} as any;
+      
+      // Create
+      const created = controller.create(createDto);
+      expect(created).toBeDefined();
+      expect(service.create).toHaveBeenCalledWith(createDto);
+
+      // Find all
+      const all = controller.findAll();
+      expect(all).toBeDefined();
+      expect(service.findAll).toHaveBeenCalled();
+
+      // Find one
+      const one = controller.findOne('1');
+      expect(one).toBeDefined();
+      expect(service.findOne).toHaveBeenCalledWith(1);
+
+      // Update
+      const updateDto: UpdateFacultyDto = {} as any;
+      const updated = controller.update('1', updateDto);
+      expect(updated).toBeDefined();
+      expect(service.update).toHaveBeenCalledWith(1, updateDto);
+
+      // Remove
+      const removed = controller.remove('1');
+      expect(removed).toBeDefined();
+      expect(service.remove).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/src/test/group-schedules.controller.spec.ts
+++ b/src/test/group-schedules.controller.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GroupSchedulesController } from '../group-schedules/group-schedules.controller';
+import { GroupSchedulesService } from '../group-schedules/services/group-schedules.service';
+import { CreateGroupScheduleDto } from '../group-schedules/dto/create-group-schedule.dto';
+import { UpdateGroupScheduleDto } from '../group-schedules/dto/update-group-schedule.dto';
+
+describe('GroupSchedulesController', () => {
+  let controller: GroupSchedulesController;
+  let service: GroupSchedulesService;
+
+  const mockGroupSchedulesService = {
+    create: jest.fn().mockReturnValue('This action adds a new groupSchedule'),
+    findAll: jest.fn().mockReturnValue(['This action returns all groupSchedules']),
+    findOne: jest.fn().mockReturnValue('This action returns a #1 groupSchedule'),
+    update: jest.fn().mockReturnValue('This action updates a #1 groupSchedule'),
+    remove: jest.fn().mockReturnValue('This action removes a #1 groupSchedule'),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GroupSchedulesController],
+      providers: [
+        {
+          provide: GroupSchedulesService,
+          useValue: mockGroupSchedulesService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<GroupSchedulesController>(GroupSchedulesController);
+    service = module.get<GroupSchedulesService>(GroupSchedulesService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a new groupSchedule', () => {
+      const createDto: CreateGroupScheduleDto = {} as any;
+      const result = controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledWith(createDto);
+      expect(result).toBe('This action adds a new groupSchedule');
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all groupSchedules', () => {
+      const result = controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toEqual(['This action returns all groupSchedules']);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single groupSchedule', () => {
+      const id = '1';
+      const result = controller.findOne(id);
+
+      expect(service.findOne).toHaveBeenCalledWith(1);
+      expect(result).toBe('This action returns a #1 groupSchedule');
+    });
+  });
+
+  describe('update', () => {
+    it('should update a groupSchedule', () => {
+      const id = '1';
+      const updateDto: UpdateGroupScheduleDto = {} as any;
+      const result = controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(1, updateDto);
+      expect(result).toBe('This action updates a #1 groupSchedule');
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a groupSchedule', () => {
+      const id = '1';
+      const result = controller.remove(id);
+
+      expect(service.remove).toHaveBeenCalledWith(1);
+      expect(result).toBe('This action removes a #1 groupSchedule');
+    });
+  });
+});

--- a/src/test/observations.validator.spec.ts
+++ b/src/test/observations.validator.spec.ts
@@ -1,0 +1,172 @@
+import { IsValidObservationsConstraint } from '../common/validators/observations.validator';
+import { ValidationArguments } from 'class-validator';
+
+describe('ObservationsValidator', () => {
+  let validator: IsValidObservationsConstraint;
+  
+  const createMockValidationArguments = (constraints: any[]): ValidationArguments => ({
+    targetName: 'TestClass',
+    property: 'observations',
+    object: {},
+    value: '',
+    constraints,
+  });
+
+  beforeEach(() => {
+    validator = new IsValidObservationsConstraint();
+  });
+
+  describe('validate', () => {
+    it('should accept null observations', () => {
+      const args = createMockValidationArguments([2000]);
+      expect(validator.validate(null, args)).toBe(true);
+    });
+
+    it('should accept short observation', () => {
+      const args = createMockValidationArguments([2000]);
+      const observation = 'Esta es una observación corta.';
+      expect(validator.validate(observation, args)).toBe(true);
+    });
+
+    it('should accept observation at max length', () => {
+      const args = createMockValidationArguments([100]);
+      const observation = 'a'.repeat(100);
+      expect(validator.validate(observation, args)).toBe(true);
+    });
+
+    it('should reject observation exceeding max length', () => {
+      const args = createMockValidationArguments([100]);
+      const observation = 'a'.repeat(101);
+      expect(validator.validate(observation, args)).toBe(false);
+    });
+
+    it('should use default max length of 2000 when not specified', () => {
+      const args = createMockValidationArguments([]);
+      const observation = 'a'.repeat(2000);
+      expect(validator.validate(observation, args)).toBe(true);
+    });
+
+    it('should reject observation exceeding default max length', () => {
+      const args = createMockValidationArguments([]);
+      const observation = 'a'.repeat(2001);
+      expect(validator.validate(observation, args)).toBe(false);
+    });
+
+    it('should accept empty string', () => {
+      const args = createMockValidationArguments([2000]);
+      expect(validator.validate('', args)).toBe(true);
+    });
+
+    it('should accept observation with line breaks', () => {
+      const args = createMockValidationArguments([200]);
+      const observation = 'Línea 1\nLínea 2\nLínea 3';
+      expect(validator.validate(observation, args)).toBe(true);
+    });
+
+    it('should accept observation with special characters', () => {
+      const args = createMockValidationArguments([200]);
+      const observation = 'Observación con áéíóú ñ ¿? ¡!';
+      expect(validator.validate(observation, args)).toBe(true);
+    });
+
+    it('should handle custom max length', () => {
+      const args = createMockValidationArguments([50]);
+      const shortObs = 'a'.repeat(50);
+      const longObs = 'a'.repeat(51);
+      
+      expect(validator.validate(shortObs, args)).toBe(true);
+      expect(validator.validate(longObs, args)).toBe(false);
+    });
+
+    it('should handle very large max length', () => {
+      const args = createMockValidationArguments([10000]);
+      const observation = 'a'.repeat(5000);
+      expect(validator.validate(observation, args)).toBe(true);
+    });
+
+    it('should handle small max length', () => {
+      const args = createMockValidationArguments([10]);
+      const observation = 'short';
+      expect(validator.validate(observation, args)).toBe(true);
+    });
+
+    it('should reject when observation is exactly one char over limit', () => {
+      const args = createMockValidationArguments([100]);
+      const observation = 'a'.repeat(101);
+      expect(validator.validate(observation, args)).toBe(false);
+    });
+  });
+
+  describe('defaultMessage', () => {
+    it('should return message with default max length', () => {
+      const args = createMockValidationArguments([]);
+      const message = validator.defaultMessage(args);
+      expect(message).toContain('2000 caracteres');
+    });
+
+    it('should return message with custom max length', () => {
+      const args = createMockValidationArguments([500]);
+      const message = validator.defaultMessage(args);
+      expect(message).toContain('500 caracteres');
+    });
+
+    it('should return message with small max length', () => {
+      const args = createMockValidationArguments([50]);
+      const message = validator.defaultMessage(args);
+      expect(message).toContain('50 caracteres');
+    });
+
+    it('should include "observaciones" in message', () => {
+      const args = createMockValidationArguments([1000]);
+      const message = validator.defaultMessage(args);
+      expect(message).toContain('observaciones');
+    });
+
+    it('should include "no pueden exceder" in message', () => {
+      const args = createMockValidationArguments([1000]);
+      const message = validator.defaultMessage(args);
+      expect(message).toContain('no pueden exceder');
+    });
+  });
+
+  describe('Integration: Realistic scenarios', () => {
+    it('should validate typical student observation', () => {
+      const args = createMockValidationArguments([2000]);
+      const observation = `Estudiante destacado en matemáticas.
+Requiere apoyo en inglés.
+
+Observaciones adicionales:
+- Participa activamente en clase
+- Buena asistencia
+- Muestra interés en las actividades`;
+      
+      expect(validator.validate(observation, args)).toBe(true);
+    });
+
+    it('should reject extremely long observation', () => {
+      const args = createMockValidationArguments([2000]);
+      const observation = 'a'.repeat(3000);
+      
+      expect(validator.validate(observation, args)).toBe(false);
+    });
+
+    it('should handle multi-paragraph observation', () => {
+      const args = createMockValidationArguments([5000]);
+      const observation = `Primer párrafo con información relevante.
+
+Segundo párrafo con más detalles.
+
+Tercer párrafo con conclusiones.`;
+      
+      expect(validator.validate(observation, args)).toBe(true);
+    });
+
+    it('should validate observation at exact limit', () => {
+      const args = createMockValidationArguments([100]);
+      const observation = 'x'.repeat(100);
+      
+      expect(validator.validate(observation, args)).toBe(true);
+      expect(validator.validate(observation + 'y', args)).toBe(false);
+    });
+  });
+});

--- a/src/test/priority-calculator.service.spec.ts
+++ b/src/test/priority-calculator.service.spec.ts
@@ -1,0 +1,468 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  PriorityCalculatorService,
+  Priority,
+  PriorityContext,
+  AddDropPeriodConfig,
+} from '../common/services/priority-calculator.service';
+
+describe('PriorityCalculatorService', () => {
+  let service: PriorityCalculatorService;
+
+  const mockUserId = '60d5ecb8b0a7c4b4b8b9b1a1';
+  const mockSourceSubjectId = '60d5ecb8b0a7c4b4b8b9b1a2';
+  const mockTargetSubjectId = '60d5ecb8b0a7c4b4b8b9b1a3';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PriorityCalculatorService],
+    }).compile();
+
+    service = module.get<PriorityCalculatorService>(PriorityCalculatorService);
+  });
+
+  describe('calculatePriority', () => {
+    it('should return NORMAL priority by default', () => {
+      const context: PriorityContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+      };
+
+      const result = service.calculatePriority(context);
+
+      expect(result).toBe(Priority.NORMAL);
+    });
+
+    it('should return HIGH priority for students in semester 10 or above', () => {
+      const context: PriorityContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        studentSemester: 10,
+      };
+
+      const result = service.calculatePriority(context);
+
+      expect(result).toBe(Priority.HIGH);
+    });
+
+    it('should return HIGH priority for mandatory target subject', () => {
+      const context: PriorityContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        isTargetMandatory: true,
+      };
+
+      const result = service.calculatePriority(context);
+
+      expect(result).toBe(Priority.HIGH);
+    });
+
+    it('should return LOW priority during add/drop period', () => {
+      const context: PriorityContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        isAddDropPeriod: true,
+      };
+
+      const result = service.calculatePriority(context);
+
+      expect(result).toBe(Priority.LOW);
+    });
+
+    it('should return URGENT priority for senior students with mandatory subject', () => {
+      const context: PriorityContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        studentSemester: 11,
+        isTargetMandatory: true,
+      };
+
+      const result = service.calculatePriority(context);
+
+      expect(result).toBe(Priority.URGENT);
+    });
+
+    it('should return HIGH priority for senior students even without mandatory flag', () => {
+      const context: PriorityContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        studentSemester: 12,
+        isTargetMandatory: false,
+      };
+
+      const result = service.calculatePriority(context);
+
+      expect(result).toBe(Priority.HIGH);
+    });
+
+    it('should prioritize URGENT over add/drop period reduction', () => {
+      const context: PriorityContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        studentSemester: 10,
+        isTargetMandatory: true,
+        isAddDropPeriod: true,
+      };
+
+      const result = service.calculatePriority(context);
+
+      // La lógica del servicio primero evalúa add/drop (LOW), pero luego 
+      // los criterios de estudiante avanzado + obligatoria lo elevan a URGENT
+      expect(result).toBe(Priority.URGENT);
+    });
+
+    it('should handle students below semester 10 as NORMAL', () => {
+      const context: PriorityContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        studentSemester: 5,
+      };
+
+      const result = service.calculatePriority(context);
+
+      expect(result).toBe(Priority.NORMAL);
+    });
+
+    it('should return NORMAL on calculation error', () => {
+      // Usar un contexto con datos malformados que cause error en la lógica
+      const context: any = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        studentSemester: 'invalid' as any, // Tipo inválido que causará error en comparación
+      };
+
+      // El servicio tiene try-catch y retorna NORMAL en caso de error
+      const result = service.calculatePriority(context);
+
+      expect(result).toBe(Priority.NORMAL);
+    });
+
+    it('should handle edge case: semester exactly 10', () => {
+      const context: PriorityContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        studentSemester: 10,
+      };
+
+      const result = service.calculatePriority(context);
+
+      expect(result).toBe(Priority.HIGH);
+    });
+  });
+
+  describe('getPriorityDescription', () => {
+    it('should return correct description for LOW priority', () => {
+      const result = service.getPriorityDescription(Priority.LOW);
+
+      expect(result).toBe('Prioridad baja - Periodo add/drop o electivas');
+    });
+
+    it('should return correct description for NORMAL priority', () => {
+      const result = service.getPriorityDescription(Priority.NORMAL);
+
+      expect(result).toBe('Prioridad normal - Solicitud estándar');
+    });
+
+    it('should return correct description for HIGH priority', () => {
+      const result = service.getPriorityDescription(Priority.HIGH);
+
+      expect(result).toBe('Prioridad alta - Materia obligatoria o estudiante avanzado');
+    });
+
+    it('should return correct description for URGENT priority', () => {
+      const result = service.getPriorityDescription(Priority.URGENT);
+
+      expect(result).toBe(
+        'Prioridad urgente - Estudiante próximo a graduar con materia obligatoria',
+      );
+    });
+  });
+
+  describe('getPriorityWeight', () => {
+    it('should return weight 1 for LOW priority', () => {
+      const result = service.getPriorityWeight(Priority.LOW);
+
+      expect(result).toBe(1);
+    });
+
+    it('should return weight 2 for NORMAL priority', () => {
+      const result = service.getPriorityWeight(Priority.NORMAL);
+
+      expect(result).toBe(2);
+    });
+
+    it('should return weight 3 for HIGH priority', () => {
+      const result = service.getPriorityWeight(Priority.HIGH);
+
+      expect(result).toBe(3);
+    });
+
+    it('should return weight 4 for URGENT priority', () => {
+      const result = service.getPriorityWeight(Priority.URGENT);
+
+      expect(result).toBe(4);
+    });
+
+    it('should allow sorting by priority weight', () => {
+      const priorities = [Priority.LOW, Priority.URGENT, Priority.NORMAL, Priority.HIGH];
+
+      const sorted = priorities.sort(
+        (a, b) => service.getPriorityWeight(b) - service.getPriorityWeight(a),
+      );
+
+      expect(sorted).toEqual([Priority.URGENT, Priority.HIGH, Priority.NORMAL, Priority.LOW]);
+    });
+  });
+
+  describe('isAddDropPeriod', () => {
+    it('should return true for date in first add/drop period (days 15-29)', () => {
+      // Día 20 del año (20 de enero aproximadamente)
+      const date = new Date(2024, 0, 20); // Enero 20
+
+      const result = service.isAddDropPeriod(date);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true for date in second add/drop period (days 195-209)', () => {
+      // Día 200 del año (julio aproximadamente)
+      const date = new Date(2024, 6, 18); // Julio 18 = día ~200
+
+      const result = service.isAddDropPeriod(date);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for date outside add/drop periods', () => {
+      // Marzo (día ~60-90)
+      const date = new Date(2024, 2, 15); // Marzo 15
+
+      const result = service.isAddDropPeriod(date);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for date at boundary before period', () => {
+      // Día 14 (fuera del primer periodo)
+      const date = new Date(2024, 0, 14); // Enero 14
+
+      const result = service.isAddDropPeriod(date);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for date at boundary after period', () => {
+      // Día 30 (fuera del primer periodo)
+      const date = new Date(2024, 0, 30); // Enero 30
+
+      const result = service.isAddDropPeriod(date);
+
+      expect(result).toBe(false);
+    });
+
+    it('should use current date when no date provided', () => {
+      const result = service.isAddDropPeriod();
+
+      expect(typeof result).toBe('boolean');
+    });
+
+    it('should return false on error', () => {
+      const invalidDate = new Date('invalid');
+
+      const result = service.isAddDropPeriod(invalidDate);
+
+      expect(result).toBe(false);
+    });
+
+    it('should handle leap year correctly', () => {
+      const date = new Date(2024, 1, 29); // Feb 29, 2024 (leap year)
+
+      const result = service.isAddDropPeriod(date);
+
+      expect(typeof result).toBe('boolean');
+    });
+  });
+
+  describe('setAddDropPeriods', () => {
+    it('should update add/drop periods correctly', () => {
+      const newPeriods: AddDropPeriodConfig[] = [
+        { startDay: 10, endDay: 20 },
+        { startDay: 180, endDay: 190 },
+      ];
+
+      service.setAddDropPeriods(newPeriods);
+
+      const periods = service.getAddDropPeriods();
+      expect(periods).toEqual(newPeriods);
+    });
+
+    it('should replace existing periods completely', () => {
+      const newPeriods: AddDropPeriodConfig[] = [{ startDay: 100, endDay: 110 }];
+
+      service.setAddDropPeriods(newPeriods);
+
+      const periods = service.getAddDropPeriods();
+      expect(periods).toHaveLength(1);
+      expect(periods[0]).toEqual({ startDay: 100, endDay: 110 });
+    });
+
+    it('should throw error for invalid period (startDay < 1)', () => {
+      const invalidPeriods: AddDropPeriodConfig[] = [{ startDay: 0, endDay: 10 }];
+
+      expect(() => service.setAddDropPeriods(invalidPeriods)).toThrow();
+    });
+
+    it('should throw error for invalid period (endDay > 366)', () => {
+      const invalidPeriods: AddDropPeriodConfig[] = [{ startDay: 100, endDay: 367 }];
+
+      expect(() => service.setAddDropPeriods(invalidPeriods)).toThrow();
+    });
+
+    it('should throw error for invalid period (startDay > endDay)', () => {
+      const invalidPeriods: AddDropPeriodConfig[] = [{ startDay: 50, endDay: 40 }];
+
+      expect(() => service.setAddDropPeriods(invalidPeriods)).toThrow(/Periodo inválido/);
+    });
+
+    it('should validate all periods before applying changes', () => {
+      const mixedPeriods: AddDropPeriodConfig[] = [
+        { startDay: 10, endDay: 20 },
+        { startDay: 200, endDay: 100 }, // Invalid
+      ];
+
+      expect(() => service.setAddDropPeriods(mixedPeriods)).toThrow();
+    });
+
+    it('should accept empty array', () => {
+      service.setAddDropPeriods([]);
+
+      const periods = service.getAddDropPeriods();
+      expect(periods).toHaveLength(0);
+    });
+
+    it('should accept multiple valid periods', () => {
+      const periods: AddDropPeriodConfig[] = [
+        { startDay: 1, endDay: 10 },
+        { startDay: 50, endDay: 60 },
+        { startDay: 100, endDay: 110 },
+      ];
+
+      service.setAddDropPeriods(periods);
+
+      const result = service.getAddDropPeriods();
+      expect(result).toHaveLength(3);
+    });
+  });
+
+  describe('getAddDropPeriods', () => {
+    it('should return default periods initially', () => {
+      const periods = service.getAddDropPeriods();
+
+      expect(periods).toHaveLength(2);
+      expect(periods[0]).toEqual({ startDay: 15, endDay: 29 });
+      expect(periods[1]).toEqual({ startDay: 195, endDay: 209 });
+    });
+
+    it('should return copy of periods (not original array)', () => {
+      const periods1 = service.getAddDropPeriods();
+      const periods2 = service.getAddDropPeriods();
+
+      expect(periods1).not.toBe(periods2); // Different array instances
+      expect(periods1).toEqual(periods2); // Same content
+    });
+
+    it('should not allow external modification', () => {
+      const periods = service.getAddDropPeriods();
+      periods.push({ startDay: 300, endDay: 310 });
+
+      const freshPeriods = service.getAddDropPeriods();
+      expect(freshPeriods).toHaveLength(2); // Original length preserved
+    });
+  });
+
+  describe('Integration scenarios', () => {
+    it('should calculate priority and provide full context', () => {
+      const context: PriorityContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        studentSemester: 11,
+        isTargetMandatory: true,
+        isAddDropPeriod: false,
+        requestDate: new Date(),
+      };
+
+      const priority = service.calculatePriority(context);
+      const description = service.getPriorityDescription(priority);
+      const weight = service.getPriorityWeight(priority);
+
+      expect(priority).toBe(Priority.URGENT);
+      expect(description).toContain('urgente');
+      expect(weight).toBe(4);
+    });
+
+    it('should handle complex priority scenario with add/drop override', () => {
+      // Configurar periodo add/drop que incluya hoy
+      const today = new Date();
+      const dayOfYear = Math.floor(
+        (today.getTime() - new Date(today.getFullYear(), 0, 0).getTime()) /
+          (1000 * 60 * 60 * 24),
+      );
+
+      service.setAddDropPeriods([{ startDay: dayOfYear - 1, endDay: dayOfYear + 1 }]);
+
+      const isInPeriod = service.isAddDropPeriod();
+      expect(isInPeriod).toBe(true);
+
+      const context: PriorityContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        isAddDropPeriod: isInPeriod,
+      };
+
+      const priority = service.calculatePriority(context);
+      expect(priority).toBe(Priority.LOW);
+    });
+
+    it('should support multiple requests with different contexts', () => {
+      const contexts: PriorityContext[] = [
+        {
+          userId: 'user1',
+          sourceSubjectId: mockSourceSubjectId,
+          targetSubjectId: mockTargetSubjectId,
+          studentSemester: 5,
+        },
+        {
+          userId: 'user2',
+          sourceSubjectId: mockSourceSubjectId,
+          targetSubjectId: mockTargetSubjectId,
+          studentSemester: 10,
+          isTargetMandatory: true,
+        },
+        {
+          userId: 'user3',
+          sourceSubjectId: mockSourceSubjectId,
+          targetSubjectId: mockTargetSubjectId,
+          isAddDropPeriod: true,
+        },
+      ];
+
+      const priorities = contexts.map((ctx) => service.calculatePriority(ctx));
+
+      expect(priorities[0]).toBe(Priority.NORMAL);
+      expect(priorities[1]).toBe(Priority.URGENT);
+      expect(priorities[2]).toBe(Priority.LOW);
+    });
+  });
+});

--- a/src/test/programs.controller.spec.ts
+++ b/src/test/programs.controller.spec.ts
@@ -1,0 +1,176 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProgramsController } from '../programs/programs.controller';
+import { ProgramsService } from '../programs/services/programs.service';
+import { CreateProgramDto } from '../programs/dto/create-program.dto';
+import { UpdateProgramDto } from '../programs/dto/update-program.dto';
+
+describe('ProgramsController', () => {
+  let controller: ProgramsController;
+  let service: ProgramsService;
+
+  const mockProgramsService = {
+    create: jest.fn().mockReturnValue('This action adds a new program'),
+    findAll: jest.fn().mockReturnValue(['This action returns all programs']),
+    findOne: jest.fn().mockReturnValue('This action returns a #1 program'),
+    update: jest.fn().mockReturnValue('This action updates a #1 program'),
+    remove: jest.fn().mockReturnValue('This action removes a #1 program'),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProgramsController],
+      providers: [
+        {
+          provide: ProgramsService,
+          useValue: mockProgramsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ProgramsController>(ProgramsController);
+    service = module.get<ProgramsService>(ProgramsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a new program', () => {
+      const createDto: CreateProgramDto = {} as any;
+      const result = controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledWith(createDto);
+      expect(result).toBe('This action adds a new program');
+    });
+
+    it('should call service create method once', () => {
+      const createDto: CreateProgramDto = {} as any;
+      controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all programs', () => {
+      const result = controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toEqual(['This action returns all programs']);
+    });
+
+    it('should call service findAll method once', () => {
+      controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single program', () => {
+      const id = '1';
+      const result = controller.findOne(id);
+
+      expect(service.findOne).toHaveBeenCalledWith(1);
+      expect(result).toBe('This action returns a #1 program');
+    });
+
+    it('should convert string id to number', () => {
+      const id = '42';
+      controller.findOne(id);
+
+      expect(service.findOne).toHaveBeenCalledWith(42);
+    });
+
+    it('should call service findOne method once', () => {
+      controller.findOne('1');
+
+      expect(service.findOne).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a program', () => {
+      const id = '1';
+      const updateDto: UpdateProgramDto = {} as any;
+      const result = controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(1, updateDto);
+      expect(result).toBe('This action updates a #1 program');
+    });
+
+    it('should convert string id to number', () => {
+      const id = '99';
+      const updateDto: UpdateProgramDto = {} as any;
+      controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(99, updateDto);
+    });
+
+    it('should call service update method once', () => {
+      controller.update('1', {} as any);
+
+      expect(service.update).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a program', () => {
+      const id = '1';
+      const result = controller.remove(id);
+
+      expect(service.remove).toHaveBeenCalledWith(1);
+      expect(result).toBe('This action removes a #1 program');
+    });
+
+    it('should convert string id to number', () => {
+      const id = '123';
+      controller.remove(id);
+
+      expect(service.remove).toHaveBeenCalledWith(123);
+    });
+
+    it('should call service remove method once', () => {
+      controller.remove('1');
+
+      expect(service.remove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Integration: Complete program lifecycle', () => {
+    it('should create, retrieve, update and delete programs', () => {
+      const createDto: CreateProgramDto = {} as any;
+      
+      // Create
+      const created = controller.create(createDto);
+      expect(created).toBeDefined();
+      expect(service.create).toHaveBeenCalledWith(createDto);
+
+      // Find all
+      const all = controller.findAll();
+      expect(all).toBeDefined();
+      expect(service.findAll).toHaveBeenCalled();
+
+      // Find one
+      const one = controller.findOne('1');
+      expect(one).toBeDefined();
+      expect(service.findOne).toHaveBeenCalledWith(1);
+
+      // Update
+      const updateDto: UpdateProgramDto = {} as any;
+      const updated = controller.update('1', updateDto);
+      expect(updated).toBeDefined();
+      expect(service.update).toHaveBeenCalledWith(1, updateDto);
+
+      // Remove
+      const removed = controller.remove('1');
+      expect(removed).toBeDefined();
+      expect(service.remove).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/src/test/radicado.service.spec.ts
+++ b/src/test/radicado.service.spec.ts
@@ -1,0 +1,339 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { InternalServerErrorException } from '@nestjs/common';
+import { RadicadoService } from '../common/services/radicado.service';
+import {
+  RadicadoCounter,
+  RadicadoCounterDocument,
+} from '../common/entities/radicado-counter.entity';
+
+describe('RadicadoService', () => {
+  let service: RadicadoService;
+  let radicadoCounterModel: Model<RadicadoCounterDocument>;
+
+  const mockRadicadoCounterModel = {
+    findOneAndUpdate: jest.fn(),
+    findOne: jest.fn(),
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RadicadoService,
+        {
+          provide: getModelToken(RadicadoCounter.name),
+          useValue: mockRadicadoCounterModel,
+        },
+      ],
+    }).compile();
+
+    service = module.get<RadicadoService>(RadicadoService);
+    radicadoCounterModel = module.get<Model<RadicadoCounterDocument>>(
+      getModelToken(RadicadoCounter.name),
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('generateRadicado', () => {
+    it('should generate radicado with correct format for current year', async () => {
+      const currentYear = new Date().getFullYear();
+      const mockCounter = {
+        year: currentYear,
+        sequence: 1,
+      };
+
+      (radicadoCounterModel.findOneAndUpdate as jest.Mock).mockResolvedValue(mockCounter);
+
+      const result = await service.generateRadicado();
+
+      expect(result).toBe(`${currentYear}-000001`);
+      expect(radicadoCounterModel.findOneAndUpdate).toHaveBeenCalledWith(
+        { year: currentYear },
+        { $inc: { sequence: 1 } },
+        {
+          new: true,
+          upsert: true,
+          setDefaultsOnInsert: true,
+        },
+      );
+    });
+
+    it('should pad sequence number with leading zeros', async () => {
+      const currentYear = new Date().getFullYear();
+      const mockCounter = {
+        year: currentYear,
+        sequence: 42,
+      };
+
+      (radicadoCounterModel.findOneAndUpdate as jest.Mock).mockResolvedValue(mockCounter);
+
+      const result = await service.generateRadicado();
+
+      expect(result).toBe(`${currentYear}-000042`);
+    });
+
+    it('should handle large sequence numbers correctly', async () => {
+      const currentYear = new Date().getFullYear();
+      const mockCounter = {
+        year: currentYear,
+        sequence: 123456,
+      };
+
+      (radicadoCounterModel.findOneAndUpdate as jest.Mock).mockResolvedValue(mockCounter);
+
+      const result = await service.generateRadicado();
+
+      expect(result).toBe(`${currentYear}-123456`);
+    });
+
+    it('should retry on failure and eventually succeed', async () => {
+      const currentYear = new Date().getFullYear();
+      const mockCounter = {
+        year: currentYear,
+        sequence: 5,
+      };
+
+      (radicadoCounterModel.findOneAndUpdate as jest.Mock)
+        .mockRejectedValueOnce(new Error('Database connection error'))
+        .mockResolvedValueOnce(mockCounter);
+
+      const result = await service.generateRadicado();
+
+      expect(result).toBe(`${currentYear}-000005`);
+      expect(radicadoCounterModel.findOneAndUpdate).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw InternalServerErrorException after max retries', async () => {
+      const error = new Error('Persistent database error');
+      
+      (radicadoCounterModel.findOneAndUpdate as jest.Mock).mockRejectedValue(error);
+
+      await expect(service.generateRadicado()).rejects.toThrow(InternalServerErrorException);
+      await expect(service.generateRadicado()).rejects.toThrow(
+        /No se pudo generar el radicado después de \d+ intentos/,
+      );
+
+      expect(radicadoCounterModel.findOneAndUpdate).toHaveBeenCalledTimes(6); // 3 retries x 2 calls
+    });
+
+    it('should use atomic increment operation', async () => {
+      const currentYear = new Date().getFullYear();
+      const mockCounter = {
+        year: currentYear,
+        sequence: 100,
+      };
+
+      (radicadoCounterModel.findOneAndUpdate as jest.Mock).mockResolvedValue(mockCounter);
+
+      await service.generateRadicado();
+
+      expect(radicadoCounterModel.findOneAndUpdate).toHaveBeenCalledWith(
+        expect.anything(),
+        { $inc: { sequence: 1 } },
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('getLastRadicado', () => {
+    it('should return last radicado for current year', async () => {
+      const currentYear = new Date().getFullYear();
+      const mockCounter = {
+        year: currentYear,
+        sequence: 42,
+      };
+
+      (radicadoCounterModel.findOne as jest.Mock).mockResolvedValue(mockCounter);
+
+      const result = await service.getLastRadicado();
+
+      expect(result).toBe(`${currentYear}-000042`);
+      expect(radicadoCounterModel.findOne).toHaveBeenCalledWith({ year: currentYear });
+    });
+
+    it('should return last radicado for specified year', async () => {
+      const year = 2023;
+      const mockCounter = {
+        year: 2023,
+        sequence: 156,
+      };
+
+      (radicadoCounterModel.findOne as jest.Mock).mockResolvedValue(mockCounter);
+
+      const result = await service.getLastRadicado(year);
+
+      expect(result).toBe('2023-000156');
+      expect(radicadoCounterModel.findOne).toHaveBeenCalledWith({ year: 2023 });
+    });
+
+    it('should return null when no radicados exist for year', async () => {
+      (radicadoCounterModel.findOne as jest.Mock).mockResolvedValue(null);
+
+      const result = await service.getLastRadicado();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when sequence is zero', async () => {
+      const currentYear = new Date().getFullYear();
+      const mockCounter = {
+        year: currentYear,
+        sequence: 0,
+      };
+
+      (radicadoCounterModel.findOne as jest.Mock).mockResolvedValue(mockCounter);
+
+      const result = await service.getLastRadicado();
+
+      expect(result).toBeNull();
+    });
+
+    it('should throw InternalServerErrorException on database error', async () => {
+      (radicadoCounterModel.findOne as jest.Mock).mockRejectedValue(
+        new Error('Database error'),
+      );
+
+      await expect(service.getLastRadicado()).rejects.toThrow(InternalServerErrorException);
+      await expect(service.getLastRadicado()).rejects.toThrow(
+        'Error al consultar el último radicado',
+      );
+    });
+  });
+
+  describe('getRadicadoStats', () => {
+    it('should return statistics for all years', async () => {
+      const mockStats = [
+        { year: 2024, sequence: 500 },
+        { year: 2023, sequence: 450 },
+        { year: 2022, sequence: 400 },
+      ];
+
+      const mockQuery = {
+        sort: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue(mockStats),
+      };
+
+      (radicadoCounterModel.find as jest.Mock).mockReturnValue(mockQuery);
+
+      const result = await service.getRadicadoStats();
+
+      expect(result).toEqual([
+        { year: 2024, count: 500 },
+        { year: 2023, count: 450 },
+        { year: 2022, count: 400 },
+      ]);
+      expect(radicadoCounterModel.find).toHaveBeenCalledWith(
+        {},
+        { year: 1, sequence: 1, _id: 0 },
+      );
+      expect(mockQuery.sort).toHaveBeenCalledWith({ year: -1 });
+    });
+
+    it('should return empty array when no statistics exist', async () => {
+      const mockQuery = {
+        sort: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue([]),
+      };
+
+      (radicadoCounterModel.find as jest.Mock).mockReturnValue(mockQuery);
+
+      const result = await service.getRadicadoStats();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should sort statistics by year descending', async () => {
+      const mockStats = [
+        { year: 2024, sequence: 100 },
+        { year: 2023, sequence: 200 },
+      ];
+
+      const mockQuery = {
+        sort: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue(mockStats),
+      };
+
+      (radicadoCounterModel.find as jest.Mock).mockReturnValue(mockQuery);
+
+      await service.getRadicadoStats();
+
+      expect(mockQuery.sort).toHaveBeenCalledWith({ year: -1 });
+    });
+
+    it('should throw InternalServerErrorException on database error', async () => {
+      const mockQuery = {
+        sort: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockRejectedValue(new Error('Database error')),
+      };
+
+      (radicadoCounterModel.find as jest.Mock).mockReturnValue(mockQuery);
+
+      await expect(service.getRadicadoStats()).rejects.toThrow(InternalServerErrorException);
+      await expect(service.getRadicadoStats()).rejects.toThrow(
+        'Error al consultar estadísticas de radicados',
+      );
+    });
+
+    it('should transform sequence to count in results', async () => {
+      const mockStats = [
+        { year: 2024, sequence: 999 },
+      ];
+
+      const mockQuery = {
+        sort: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue(mockStats),
+      };
+
+      (radicadoCounterModel.find as jest.Mock).mockReturnValue(mockQuery);
+
+      const result = await service.getRadicadoStats();
+
+      expect(result[0]).toHaveProperty('count', 999);
+      expect(result[0]).not.toHaveProperty('sequence');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle year transition correctly', async () => {
+      const currentYear = new Date().getFullYear();
+      const mockCounter = {
+        year: currentYear,
+        sequence: 1000,
+      };
+
+      (radicadoCounterModel.findOneAndUpdate as jest.Mock).mockResolvedValue(mockCounter);
+
+      const result = await service.generateRadicado();
+
+      expect(result).toMatch(/^\d{4}-\d{6}$/);
+      expect(result).toBe(`${currentYear}-001000`);
+    });
+
+    it('should handle concurrent radicado generation', async () => {
+      const mockCounters = [
+        { year: 2024, sequence: 1 },
+        { year: 2024, sequence: 2 },
+        { year: 2024, sequence: 3 },
+      ];
+
+      let callCount = 0;
+      (radicadoCounterModel.findOneAndUpdate as jest.Mock).mockImplementation(() => {
+        return Promise.resolve(mockCounters[callCount++]);
+      });
+
+      const results = await Promise.all([
+        service.generateRadicado(),
+        service.generateRadicado(),
+        service.generateRadicado(),
+      ]);
+
+      expect(results).toHaveLength(3);
+      expect(new Set(results).size).toBe(3); // All unique
+    });
+  });
+});

--- a/src/test/reports.controller.spec.ts
+++ b/src/test/reports.controller.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReportsController } from '../reports/reports.controller';
+import { ReportsService } from '../reports/services/reports.service';
+import { CreateReportDto } from '../reports/dto/create-report.dto';
+import { UpdateReportDto } from '../reports/dto/update-report.dto';
+
+describe('ReportsController', () => {
+  let controller: ReportsController;
+  let service: ReportsService;
+
+  const mockReportsService = {
+    create: jest.fn().mockReturnValue('This action adds a new report'),
+    findAll: jest.fn().mockReturnValue(['This action returns all reports']),
+    findOne: jest.fn().mockReturnValue('This action returns a #1 report'),
+    update: jest.fn().mockReturnValue('This action updates a #1 report'),
+    remove: jest.fn().mockReturnValue('This action removes a #1 report'),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ReportsController],
+      providers: [
+        {
+          provide: ReportsService,
+          useValue: mockReportsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ReportsController>(ReportsController);
+    service = module.get<ReportsService>(ReportsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a new report', () => {
+      const createDto: CreateReportDto = {} as any;
+      const result = controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledWith(createDto);
+      expect(result).toBe('This action adds a new report');
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all reports', () => {
+      const result = controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toEqual(['This action returns all reports']);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single report', () => {
+      const id = '1';
+      const result = controller.findOne(id);
+
+      expect(service.findOne).toHaveBeenCalledWith(+id);
+      expect(result).toBe('This action returns a #1 report');
+    });
+  });
+
+  describe('update', () => {
+    it('should update a report', () => {
+      const id = '1';
+      const updateDto: UpdateReportDto = {} as any;
+      const result = controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(+id, updateDto);
+      expect(result).toBe('This action updates a #1 report');
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a report', () => {
+      const id = '1';
+      const result = controller.remove(id);
+
+      expect(service.remove).toHaveBeenCalledWith(+id);
+      expect(result).toBe('This action removes a #1 report');
+    });
+  });
+});

--- a/src/test/roles.controller.spec.ts
+++ b/src/test/roles.controller.spec.ts
@@ -1,0 +1,33 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RolesController } from '../roles/roles.controller';
+import { RolesService } from '../roles/services/roles.service';
+
+describe('RolesController', () => {
+  let controller: RolesController;
+  let service: RolesService;
+
+  const mockRolesService = {};
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RolesController],
+      providers: [
+        {
+          provide: RolesService,
+          useValue: mockRolesService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<RolesController>(RolesController);
+    service = module.get<RolesService>(RolesService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should have RolesService injected', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/test/roles.service.spec.ts
+++ b/src/test/roles.service.spec.ts
@@ -1,0 +1,444 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { RolesService } from '../roles/services/roles.service';
+import {
+  Role,
+  RoleDocument,
+  RoleName,
+  Permission,
+} from '../roles/entities/role.entity';
+
+describe('RolesService', () => {
+  let service: RolesService;
+  let roleModel: Model<RoleDocument>;
+
+  const mockRoles = [
+    {
+      _id: 'role1',
+      name: RoleName.ADMIN,
+      displayName: 'Administrator',
+      description: 'Full access',
+      permissions: Object.values(Permission),
+      isActive: true,
+      priority: 4,
+    },
+    {
+      _id: 'role2',
+      name: RoleName.DEAN,
+      displayName: 'Dean',
+      description: 'Academic management',
+      permissions: [Permission.READ_USER, Permission.READ_COURSE],
+      isActive: true,
+      priority: 3,
+    },
+    {
+      _id: 'role3',
+      name: RoleName.STUDENT,
+      displayName: 'Student',
+      description: 'Basic access',
+      permissions: [Permission.READ_COURSE, Permission.READ_ENROLLMENT],
+      isActive: true,
+      priority: 1,
+    },
+  ];
+
+  beforeEach(async () => {
+    const mockRoleModel = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+      countDocuments: jest.fn(),
+      create: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RolesService,
+        {
+          provide: getModelToken(Role.name),
+          useValue: mockRoleModel,
+        },
+      ],
+    }).compile();
+
+    service = module.get<RolesService>(RolesService);
+    roleModel = module.get<Model<RoleDocument>>(getModelToken(Role.name));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('onModuleInit', () => {
+    it('should initialize default roles when none exist', async () => {
+      (roleModel.findOne as jest.Mock).mockResolvedValue(null);
+
+      const createdRoles: any[] = [];
+      (roleModel.create as jest.Mock).mockImplementation((role) => {
+        createdRoles.push(role);
+        return Promise.resolve(role);
+      });
+
+      await service.onModuleInit();
+
+      expect(roleModel.create).toHaveBeenCalledTimes(3);
+      expect(createdRoles.find((r) => r.name === RoleName.ADMIN)).toBeDefined();
+      expect(createdRoles.find((r) => r.name === RoleName.DEAN)).toBeDefined();
+      expect(createdRoles.find((r) => r.name === RoleName.STUDENT)).toBeDefined();
+    });
+
+    it('should not initialize roles when they already exist', async () => {
+      (roleModel.findOne as jest.Mock).mockResolvedValue(mockRoles[0]);
+
+      await service.onModuleInit();
+
+      expect(roleModel.create).not.toHaveBeenCalled();
+    });
+
+    it('should create ADMIN role with all permissions', async () => {
+      (roleModel.findOne as jest.Mock).mockResolvedValue(null);
+
+      let adminRole: any;
+      (roleModel.create as jest.Mock).mockImplementation((role) => {
+        if (role.name === RoleName.ADMIN) {
+          adminRole = role;
+        }
+        return Promise.resolve(role);
+      });
+
+      await service.onModuleInit();
+
+      expect(adminRole).toBeDefined();
+      expect(adminRole.priority).toBe(4);
+      expect(adminRole.permissions).toContain(Permission.CREATE_USER);
+      expect(adminRole.permissions).toContain(Permission.DELETE_USER);
+    });
+
+    it('should create DEAN role with limited permissions', async () => {
+      (roleModel.findOne as jest.Mock).mockResolvedValue(null);
+
+      let deanRole: any;
+      (roleModel.create as jest.Mock).mockImplementation((role) => {
+        if (role.name === RoleName.DEAN) {
+          deanRole = role;
+        }
+        return Promise.resolve(role);
+      });
+
+      await service.onModuleInit();
+
+      expect(deanRole).toBeDefined();
+      expect(deanRole.priority).toBe(3);
+      expect(deanRole.permissions.length).toBeGreaterThan(0);
+    });
+
+    it('should create STUDENT role with minimal permissions', async () => {
+      (roleModel.findOne as jest.Mock).mockResolvedValue(null);
+
+      let studentRole: any;
+      (roleModel.create as jest.Mock).mockImplementation((role) => {
+        if (role.name === RoleName.STUDENT) {
+          studentRole = role;
+        }
+        return Promise.resolve(role);
+      });
+
+      await service.onModuleInit();
+
+      expect(studentRole).toBeDefined();
+      expect(studentRole.priority).toBe(1);
+      expect(studentRole.permissions).toContain(Permission.READ_COURSE);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all active roles sorted by priority', async () => {
+      const mockChain = {
+        sort: jest.fn().mockResolvedValue(mockRoles),
+      };
+      (roleModel.find as jest.Mock).mockReturnValue(mockChain);
+
+      const result = await service.findAll();
+
+      expect(roleModel.find).toHaveBeenCalledWith({ isActive: true });
+      expect(mockChain.sort).toHaveBeenCalledWith({ priority: -1 });
+      expect(result).toEqual(mockRoles);
+      expect(result).toHaveLength(3);
+    });
+
+    it('should return empty array when no roles exist', async () => {
+      const mockChain = {
+        sort: jest.fn().mockResolvedValue([]),
+      };
+      (roleModel.find as jest.Mock).mockReturnValue(mockChain);
+
+      const result = await service.findAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findByName', () => {
+    it('should return a role by name', async () => {
+      (roleModel.findOne as jest.Mock).mockResolvedValue(mockRoles[0]);
+
+      const result = await service.findByName(RoleName.ADMIN);
+
+      expect(roleModel.findOne).toHaveBeenCalledWith({
+        name: RoleName.ADMIN,
+        isActive: true,
+      });
+      expect(result).toEqual(mockRoles[0]);
+    });
+
+    it('should return null when role not found', async () => {
+      (roleModel.findOne as jest.Mock).mockResolvedValue(null);
+
+      const result = await service.findByName(RoleName.ADMIN);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findByNames', () => {
+    it('should return multiple roles by names', async () => {
+      const selectedRoles = [mockRoles[0], mockRoles[2]];
+      (roleModel.find as jest.Mock).mockResolvedValue(selectedRoles);
+
+      const result = await service.findByNames([RoleName.ADMIN, RoleName.STUDENT]);
+
+      expect(roleModel.find).toHaveBeenCalledWith({
+        name: { $in: [RoleName.ADMIN, RoleName.STUDENT] },
+        isActive: true,
+      });
+      expect(result).toEqual(selectedRoles);
+    });
+
+    it('should return empty array when no matching roles', async () => {
+      (roleModel.find as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.findByNames([RoleName.ADMIN]);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('hasPermission', () => {
+    it('should return true when user has the permission', async () => {
+      (roleModel.find as jest.Mock).mockResolvedValue([mockRoles[0]]);
+
+      const result = await service.hasPermission(
+        [RoleName.ADMIN],
+        Permission.CREATE_USER,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when user does not have the permission', async () => {
+      (roleModel.find as jest.Mock).mockResolvedValue([mockRoles[2]]);
+
+      const result = await service.hasPermission(
+        [RoleName.STUDENT],
+        Permission.DELETE_USER,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when no roles found', async () => {
+      (roleModel.find as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.hasPermission(
+        [RoleName.ADMIN],
+        Permission.CREATE_USER,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should check permission across multiple roles', async () => {
+      (roleModel.find as jest.Mock).mockResolvedValue([mockRoles[1], mockRoles[2]]);
+
+      const result = await service.hasPermission(
+        [RoleName.DEAN, RoleName.STUDENT],
+        Permission.READ_USER,
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('getUserPermissions', () => {
+    it('should return all permissions for a user', async () => {
+      (roleModel.find as jest.Mock).mockResolvedValue([mockRoles[1], mockRoles[2]]);
+
+      const result = await service.getUserPermissions([
+        RoleName.DEAN,
+        RoleName.STUDENT,
+      ]);
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result).toContain(Permission.READ_USER);
+      expect(result).toContain(Permission.READ_COURSE);
+    });
+
+    it('should return unique permissions', async () => {
+      const rolesWithDuplicate = [
+        {
+          ...mockRoles[1],
+          permissions: [Permission.READ_COURSE, Permission.READ_USER],
+        },
+        {
+          ...mockRoles[2],
+          permissions: [Permission.READ_COURSE, Permission.READ_ENROLLMENT],
+        },
+      ];
+
+      (roleModel.find as jest.Mock).mockResolvedValue(rolesWithDuplicate);
+
+      const result = await service.getUserPermissions([
+        RoleName.DEAN,
+        RoleName.STUDENT,
+      ]);
+
+      const uniquePerms = [...new Set(result)];
+      expect(result.length).toBe(uniquePerms.length);
+    });
+
+    it('should return empty array when no roles found', async () => {
+      (roleModel.find as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.getUserPermissions([RoleName.ADMIN]);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('hasHigherPriority', () => {
+    it('should return true when user has higher priority role', async () => {
+      (roleModel.find as jest.Mock).mockResolvedValue([mockRoles[0]]);
+      (roleModel.findOne as jest.Mock).mockResolvedValue(mockRoles[2]);
+
+      const result = await service.hasHigherPriority(
+        [RoleName.ADMIN],
+        RoleName.STUDENT,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when user has lower priority', async () => {
+      (roleModel.find as jest.Mock).mockResolvedValue([mockRoles[2]]);
+      (roleModel.findOne as jest.Mock).mockResolvedValue(mockRoles[0]);
+
+      const result = await service.hasHigherPriority(
+        [RoleName.STUDENT],
+        RoleName.ADMIN,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when target role not found', async () => {
+      (roleModel.find as jest.Mock).mockResolvedValue([mockRoles[0]]);
+      (roleModel.findOne as jest.Mock).mockResolvedValue(null);
+
+      const result = await service.hasHigherPriority(
+        [RoleName.ADMIN],
+        RoleName.STUDENT,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should handle user with multiple roles', async () => {
+      (roleModel.find as jest.Mock).mockResolvedValue([mockRoles[0], mockRoles[2]]);
+      (roleModel.findOne as jest.Mock).mockResolvedValue(mockRoles[1]);
+
+      const result = await service.hasHigherPriority(
+        [RoleName.ADMIN, RoleName.STUDENT],
+        RoleName.DEAN,
+      );
+
+      expect(result).toBe(true); // MAX priority is ADMIN (4) > DEAN (3)
+    });
+  });
+
+  describe('isAdmin', () => {
+    it('should return true for admin users', async () => {
+      const result = service.isAdmin([RoleName.ADMIN]);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for non-admin users', async () => {
+      const result = service.isAdmin([RoleName.STUDENT]);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true if admin is in multiple roles', async () => {
+      const result = service.isAdmin([RoleName.STUDENT, RoleName.ADMIN]);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('isDean', () => {
+    it('should return true for dean users', async () => {
+      const result = service.isDean([RoleName.DEAN]);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for non-dean users', async () => {
+      const result = service.isDean([RoleName.STUDENT]);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isStudent', () => {
+    it('should return true for student users', async () => {
+      const result = service.isStudent([RoleName.STUDENT]);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for non-student users', async () => {
+      const result = service.isStudent([RoleName.ADMIN]);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('hasAdministrativeRole', () => {
+    it('should return true for admins', async () => {
+      const result = service.hasAdministrativeRole([RoleName.ADMIN]);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true for deans', async () => {
+      const result = service.hasAdministrativeRole([RoleName.DEAN]);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for students', async () => {
+      const result = service.hasAdministrativeRole([RoleName.STUDENT]);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true if user has any administrative role', async () => {
+      const result = service.hasAdministrativeRole([
+        RoleName.STUDENT,
+        RoleName.DEAN,
+      ]);
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/src/test/routing-validator.service.spec.ts
+++ b/src/test/routing-validator.service.spec.ts
@@ -1,0 +1,408 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import {
+  RoutingValidatorService,
+  ValidationResult,
+} from '../common/services/routing-validator.service';
+import { Program, ProgramDocument } from '../programs/entities/program.entity';
+
+describe('RoutingValidatorService', () => {
+  let service: RoutingValidatorService;
+  let programModel: Model<ProgramDocument>;
+
+  const mockProgramId = '60d5ecb8b0a7c4b4b8b9b1a1';
+  const mockRequestId = '60d5ecb8b0a7c4b4b8b9b1a2';
+  const mockDefaultProgram = 'PROG-ADMIN';
+  const mockEmergencyProgram = 'PROG-EMERGENCY';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RoutingValidatorService,
+        {
+          provide: getModelToken(Program.name),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<RoutingValidatorService>(RoutingValidatorService);
+    programModel = module.get<Model<ProgramDocument>>(getModelToken(Program.name));
+  });
+
+  describe('validateAndEnsureProgram', () => {
+    it('should validate successfully when program exists and is active', async () => {
+      const context = { userId: '123', sourceSubjectId: '456' };
+
+      jest.spyOn(programModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue({
+          _id: mockProgramId,
+          code: 'PROG-001',
+          name: 'Test Program',
+          isActive: true,
+        }),
+      } as any);
+
+      const result = await service.validateAndEnsureProgram(
+        mockProgramId,
+        mockRequestId,
+        context,
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.assignedProgramId).toBe(mockProgramId);
+      expect(result.fallbackUsed).toBe(false);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('should apply fallback when program does not exist', async () => {
+      const context = { userId: '123', sourceSubjectId: '456' };
+
+      let callCount = 0;
+      jest.spyOn(programModel, 'findOne').mockImplementation((query: any) => {
+        callCount++;
+        // Primera y segunda llamadas: programa original no existe
+        // Tercera y cuarta llamadas: programa por defecto existe y está activo
+        const shouldReturnNull = callCount <= 2;
+        return {
+          exec: jest.fn().mockResolvedValue(
+            shouldReturnNull
+              ? null
+              : {
+                  _id: mockDefaultProgram,
+                  code: mockDefaultProgram,
+                  name: 'Default Program',
+                  isActive: true,
+                },
+          ),
+        } as any;
+      });
+
+      const result = await service.validateAndEnsureProgram(
+        mockProgramId,
+        mockRequestId,
+        context,
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.assignedProgramId).toBe(mockDefaultProgram);
+      expect(result.fallbackUsed).toBe(true);
+      expect(result.reason).toContain('Programa original');
+      expect(result.reason).toContain('PROGRAM_NOT_EXISTS');
+    });
+
+    it('should apply fallback when program is inactive', async () => {
+      const context = { userId: '123', sourceSubjectId: '456' };
+
+      let callCount = 0;
+      jest.spyOn(programModel, 'findOne').mockImplementation((query: any) => {
+        callCount++;
+        // Primera llamada (exists): retorna programa
+        // Segunda llamada (isActive): retorna null (inactivo)
+        // Tercera y cuarta llamadas (default): retorna programa por defecto activo
+        if (callCount === 1) {
+          return {
+            exec: jest.fn().mockResolvedValue({
+              _id: mockProgramId,
+              code: 'PROG-001',
+              isActive: false,
+            }),
+          } as any;
+        } else if (callCount === 2) {
+          return {
+            exec: jest.fn().mockResolvedValue(null),
+          } as any;
+        } else {
+          return {
+            exec: jest.fn().mockResolvedValue({
+              _id: mockDefaultProgram,
+              code: mockDefaultProgram,
+              isActive: true,
+            }),
+          } as any;
+        }
+      });
+
+      const result = await service.validateAndEnsureProgram(
+        mockProgramId,
+        mockRequestId,
+        context,
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.assignedProgramId).toBe(mockDefaultProgram);
+      expect(result.fallbackUsed).toBe(true);
+      expect(result.reason).toContain('PROGRAM_INACTIVE');
+    });
+
+    it('should return emergency program when default program is invalid', async () => {
+      const context = { userId: '123', sourceSubjectId: '456' };
+
+      // Todas las llamadas retornan null (ni original ni default son válidos)
+      jest.spyOn(programModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      const result = await service.validateAndEnsureProgram(
+        mockProgramId,
+        mockRequestId,
+        context,
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.assignedProgramId).toBe(mockEmergencyProgram);
+      expect(result.fallbackUsed).toBe(true);
+      expect(result.reason).toContain('programa por defecto también inválido');
+    });
+
+    it('should handle critical errors and return emergency program', async () => {
+      const context = { userId: '123', sourceSubjectId: '456' };
+
+      jest.spyOn(programModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockRejectedValue(new Error('Database connection error')),
+      } as any);
+
+      const result = await service.validateAndEnsureProgram(
+        mockProgramId,
+        mockRequestId,
+        context,
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.assignedProgramId).toBe(mockEmergencyProgram);
+      expect(result.fallbackUsed).toBe(true);
+      // El error puede ser capturado en validateProgramExists y retornar false,
+      // lo que activa fallback con mensaje de programa inválido
+      expect(result.reason).toBeDefined();
+    });
+
+    it('should validate program by code when ID lookup fails', async () => {
+      const context = { userId: '123', sourceSubjectId: '456' };
+      const programCode = 'PROG-001';
+
+      jest.spyOn(programModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue({
+          _id: mockProgramId,
+          code: programCode,
+          name: 'Test Program',
+          isActive: true,
+        }),
+      } as any);
+
+      const result = await service.validateAndEnsureProgram(
+        programCode,
+        mockRequestId,
+        context,
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.assignedProgramId).toBe(programCode);
+      expect(result.fallbackUsed).toBe(false);
+    });
+
+    it('should handle empty context gracefully', async () => {
+      jest.spyOn(programModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue({
+          _id: mockProgramId,
+          code: 'PROG-001',
+          isActive: true,
+        }),
+      } as any);
+
+      const result = await service.validateAndEnsureProgram(mockProgramId, mockRequestId, {});
+
+      expect(result.isValid).toBe(true);
+      expect(result.assignedProgramId).toBe(mockProgramId);
+    });
+  });
+
+  describe('getDefaultProgram', () => {
+    it('should return the default program ID', () => {
+      const defaultProgram = service.getDefaultProgram();
+
+      expect(defaultProgram).toBe(mockDefaultProgram);
+    });
+
+    it('should consistently return same default program', () => {
+      const call1 = service.getDefaultProgram();
+      const call2 = service.getDefaultProgram();
+
+      expect(call1).toBe(call2);
+      expect(call1).toBe(mockDefaultProgram);
+    });
+  });
+
+  describe('shouldNotifyAdmins', () => {
+    it('should return true when fallback was used', () => {
+      const result: ValidationResult = {
+        isValid: true,
+        assignedProgramId: mockDefaultProgram,
+        fallbackUsed: true,
+        reason: 'Fallback applied',
+      };
+
+      const shouldNotify = service.shouldNotifyAdmins(result);
+
+      expect(shouldNotify).toBe(true);
+    });
+
+    it('should return true when validation failed', () => {
+      const result: ValidationResult = {
+        isValid: false,
+        assignedProgramId: mockEmergencyProgram,
+        fallbackUsed: true,
+        reason: 'Emergency program used',
+      };
+
+      const shouldNotify = service.shouldNotifyAdmins(result);
+
+      expect(shouldNotify).toBe(true);
+    });
+
+    it('should return false when validation succeeded without fallback', () => {
+      const result: ValidationResult = {
+        isValid: true,
+        assignedProgramId: mockProgramId,
+        fallbackUsed: false,
+      };
+
+      const shouldNotify = service.shouldNotifyAdmins(result);
+
+      expect(shouldNotify).toBe(false);
+    });
+
+    it('should return true even if valid but fallback was used', () => {
+      const result: ValidationResult = {
+        isValid: true,
+        assignedProgramId: mockDefaultProgram,
+        fallbackUsed: true,
+      };
+
+      const shouldNotify = service.shouldNotifyAdmins(result);
+
+      expect(shouldNotify).toBe(true);
+    });
+  });
+
+  describe('getValidationStats', () => {
+    it('should return comprehensive validation statistics', () => {
+      const stats = service.getValidationStats();
+
+      expect(stats).toHaveProperty('defaultProgram');
+      expect(stats).toHaveProperty('emergencyProgram');
+      expect(stats).toHaveProperty('validationRules');
+      expect(stats).toHaveProperty('fallbackReasons');
+    });
+
+    it('should include correct default and emergency program IDs', () => {
+      const stats = service.getValidationStats();
+
+      expect(stats.defaultProgram).toBe(mockDefaultProgram);
+      expect(stats.emergencyProgram).toBe(mockEmergencyProgram);
+    });
+
+    it('should include validation rules', () => {
+      const stats = service.getValidationStats();
+
+      expect(Array.isArray(stats.validationRules)).toBe(true);
+      expect(stats.validationRules.length).toBeGreaterThan(0);
+      expect(stats.validationRules[0]).toContain('Programa debe existir');
+    });
+
+    it('should include fallback reasons', () => {
+      const stats = service.getValidationStats();
+
+      expect(Array.isArray(stats.fallbackReasons)).toBe(true);
+      expect(stats.fallbackReasons.length).toBeGreaterThan(0);
+      expect(stats.fallbackReasons.some((r: string) => r.includes('PROGRAM_NOT_EXISTS'))).toBe(
+        true,
+      );
+      expect(stats.fallbackReasons.some((r: string) => r.includes('PROGRAM_INACTIVE'))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('Integration scenarios', () => {
+    it('should handle complete validation workflow with success', async () => {
+      const context = { userId: '123', sourceSubjectId: '456' };
+
+      jest.spyOn(programModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue({
+          _id: mockProgramId,
+          code: 'PROG-001',
+          isActive: true,
+        }),
+      } as any);
+
+      const result = await service.validateAndEnsureProgram(
+        mockProgramId,
+        mockRequestId,
+        context,
+      );
+      const shouldNotify = service.shouldNotifyAdmins(result);
+      const stats = service.getValidationStats();
+
+      expect(result.isValid).toBe(true);
+      expect(shouldNotify).toBe(false);
+      expect(stats.defaultProgram).toBe(mockDefaultProgram);
+    });
+
+    it('should handle complete validation workflow with fallback', async () => {
+      const context = { userId: '123', sourceSubjectId: '456' };
+
+      let callCount = 0;
+      jest.spyOn(programModel, 'findOne').mockImplementation(() => {
+        callCount++;
+        const shouldReturnDefault = callCount > 2;
+        return {
+          exec: jest.fn().mockResolvedValue(
+            shouldReturnDefault
+              ? {
+                  _id: mockDefaultProgram,
+                  code: mockDefaultProgram,
+                  isActive: true,
+                }
+              : null,
+          ),
+        } as any;
+      });
+
+      const result = await service.validateAndEnsureProgram(
+        mockProgramId,
+        mockRequestId,
+        context,
+      );
+      const shouldNotify = service.shouldNotifyAdmins(result);
+      const defaultProgram = service.getDefaultProgram();
+
+      expect(result.isValid).toBe(true);
+      expect(result.assignedProgramId).toBe(defaultProgram);
+      expect(result.fallbackUsed).toBe(true);
+      expect(shouldNotify).toBe(true);
+    });
+
+    it('should handle emergency scenario correctly', async () => {
+      const context = { userId: '123', sourceSubjectId: '456' };
+
+      jest.spyOn(programModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      const result = await service.validateAndEnsureProgram(
+        mockProgramId,
+        mockRequestId,
+        context,
+      );
+      const shouldNotify = service.shouldNotifyAdmins(result);
+      const stats = service.getValidationStats();
+
+      expect(result.isValid).toBe(false);
+      expect(result.assignedProgramId).toBe(stats.emergencyProgram);
+      expect(shouldNotify).toBe(true);
+    });
+  });
+});

--- a/src/test/routing.service.spec.ts
+++ b/src/test/routing.service.spec.ts
@@ -1,0 +1,411 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { RoutingService, RoutingContext } from '../common/services/routing.service';
+import { ProgramCourse, ProgramCourseDocument } from '../programs/entities/program.entity';
+import { Student, StudentDocument } from '../students/entities/student.entity';
+
+describe('RoutingService', () => {
+  let service: RoutingService;
+  let programCourseModel: Model<ProgramCourseDocument>;
+  let studentModel: Model<StudentDocument>;
+
+  const mockUserId = '60d5ecb8b0a7c4b4b8b9b1a1';
+  const mockSourceSubjectId = '60d5ecb8b0a7c4b4b8b9b1a2';
+  const mockTargetSubjectId = '60d5ecb8b0a7c4b4b8b9b1a3';
+  const mockProgramId1 = '60d5ecb8b0a7c4b4b8b9b1a4';
+  const mockProgramId2 = '60d5ecb8b0a7c4b4b8b9b1a5';
+  const mockStudentProgramId = '60d5ecb8b0a7c4b4b8b9b1a6';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RoutingService,
+        {
+          provide: getModelToken(ProgramCourse.name),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: getModelToken(Student.name),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<RoutingService>(RoutingService);
+    programCourseModel = module.get<Model<ProgramCourseDocument>>(
+      getModelToken(ProgramCourse.name),
+    );
+    studentModel = module.get<Model<StudentDocument>>(getModelToken(Student.name));
+  });
+
+  describe('determineProgram', () => {
+    it('should assign to same program when both subjects belong to same program (Rule 1)', async () => {
+      const context: RoutingContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        studentProgramId: mockStudentProgramId, // Proveer para evitar llamada a BD
+      };
+
+      // Mock para ambas materias pertenecen al mismo programa
+      jest.spyOn(programCourseModel, 'findOne').mockImplementation((query: any) => {
+        return {
+          populate: jest.fn().mockReturnValue({
+            exec: jest.fn().mockResolvedValue({
+              courseId: query.courseId,
+              programId: mockProgramId1,
+            }),
+          }),
+        } as any;
+      });
+
+      const result = await service.determineProgram(context);
+
+      expect(result.assignedProgramId).toBe(mockProgramId1);
+      expect(result.rule).toBe('SAME_PROGRAM');
+      expect(result.reason).toContain('Ambas materias pertenecen al programa');
+    });
+
+    it('should assign to target program when subjects from different programs (Rule 2)', async () => {
+      const context: RoutingContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        studentProgramId: mockStudentProgramId, // Proveer para evitar llamada a BD
+      };
+
+      let callCount = 0;
+      jest.spyOn(programCourseModel, 'findOne').mockImplementation((query: any) => {
+        callCount++;
+        return {
+          populate: jest.fn().mockReturnValue({
+            exec: jest.fn().mockResolvedValue({
+              courseId: query.courseId,
+              programId: callCount === 1 ? mockProgramId1 : mockProgramId2,
+            }),
+          }),
+        } as any;
+      });
+
+      const result = await service.determineProgram(context);
+
+      expect(result.assignedProgramId).toBe(mockProgramId2);
+      expect(result.rule).toBe('TARGET_PROGRAM');
+      expect(result.reason).toContain('Materias de diferentes programas');
+    });
+
+    it('should assign to source program when only source has program (Rule 3)', async () => {
+      const context: RoutingContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        studentProgramId: mockStudentProgramId,
+      };
+
+      let callCount = 0;
+      jest.spyOn(programCourseModel, 'findOne').mockImplementation((query: any) => {
+        callCount++;
+        return {
+          populate: jest.fn().mockReturnValue({
+            exec: jest.fn().mockResolvedValue(
+              callCount === 1
+                ? { courseId: query.courseId, programId: mockProgramId1 }
+                : null,
+            ),
+          }),
+        } as any;
+      });
+
+      const result = await service.determineProgram(context);
+
+      expect(result.assignedProgramId).toBe(mockProgramId1);
+      expect(result.rule).toBe('SOURCE_PROGRAM');
+      expect(result.reason).toContain('Solo materia origen tiene programa');
+    });
+
+    it('should assign to target program when only target has program (Rule 4)', async () => {
+      const context: RoutingContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        studentProgramId: mockStudentProgramId,
+      };
+
+      let callCount = 0;
+      jest.spyOn(programCourseModel, 'findOne').mockImplementation((query: any) => {
+        callCount++;
+        return {
+          populate: jest.fn().mockReturnValue({
+            exec: jest.fn().mockResolvedValue(
+              callCount === 2
+                ? { courseId: query.courseId, programId: mockProgramId2 }
+                : null,
+            ),
+          }),
+        } as any;
+      });
+
+      const result = await service.determineProgram(context);
+
+      expect(result.assignedProgramId).toBe(mockProgramId2);
+      expect(result.rule).toBe('TARGET_PROGRAM');
+      expect(result.reason).toContain('Solo materia destino tiene programa');
+    });
+
+    it('should fallback to student program when no subjects have programs', async () => {
+      const context: RoutingContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+      };
+
+      // Mock para ninguna materia tiene programa
+      jest.spyOn(programCourseModel, 'findOne').mockImplementation(() => {
+        return {
+          populate: jest.fn().mockReturnValue({
+            exec: jest.fn().mockResolvedValue(null),
+          }),
+        } as any;
+      });
+
+      // Mock para estudiante
+      jest.spyOn(studentModel, 'findOne').mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue({
+            externalId: mockUserId,
+            programId: mockStudentProgramId,
+          }),
+        }),
+      } as any);
+
+      const result = await service.determineProgram(context);
+
+      expect(result.assignedProgramId).toBe(mockStudentProgramId);
+      expect(result.rule).toBe('STUDENT_PROGRAM');
+      expect(result.reason).toContain('Fallback al programa del estudiante');
+    });
+
+    it('should use provided studentProgramId when available', async () => {
+      const context: RoutingContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        studentProgramId: mockStudentProgramId,
+      };
+
+      // Mock para ninguna materia tiene programa
+      jest.spyOn(programCourseModel, 'findOne').mockImplementation(() => {
+        return {
+          populate: jest.fn().mockReturnValue({
+            exec: jest.fn().mockResolvedValue(null),
+          }),
+        } as any;
+      });
+
+      const result = await service.determineProgram(context);
+
+      expect(result.assignedProgramId).toBe(mockStudentProgramId);
+      expect(result.rule).toBe('STUDENT_PROGRAM');
+      // No debe llamar a la BD para obtener el programa del estudiante
+      expect(studentModel.findOne).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when student not found', async () => {
+      const context: RoutingContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+      };
+
+      // Mock para ninguna materia tiene programa
+      jest.spyOn(programCourseModel, 'findOne').mockImplementation(() => {
+        return {
+          populate: jest.fn().mockReturnValue({
+            exec: jest.fn().mockResolvedValue(null),
+          }),
+        } as any;
+      });
+
+      // Mock para estudiante no encontrado
+      jest.spyOn(studentModel, 'findOne').mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue(null),
+        }),
+      } as any);
+
+      await expect(service.determineProgram(context)).rejects.toThrow(
+        'No se pudo determinar el programa para la solicitud',
+      );
+    });
+
+    it('should throw error when student has no program', async () => {
+      const context: RoutingContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+      };
+
+      // Mock para ninguna materia tiene programa
+      jest.spyOn(programCourseModel, 'findOne').mockImplementation(() => {
+        return {
+          populate: jest.fn().mockReturnValue({
+            exec: jest.fn().mockResolvedValue(null),
+          }),
+        } as any;
+      });
+
+      // Mock para estudiante sin programa
+      jest.spyOn(studentModel, 'findOne').mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          exec: jest.fn().mockResolvedValue({
+            externalId: mockUserId,
+            programId: null,
+          }),
+        }),
+      } as any);
+
+      await expect(service.determineProgram(context)).rejects.toThrow(
+        'No se pudo determinar el programa para la solicitud',
+      );
+    });
+
+    it('should handle database errors gracefully', async () => {
+      const context: RoutingContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+      };
+
+      jest.spyOn(programCourseModel, 'findOne').mockImplementation(() => {
+        throw new Error('Database connection error');
+      });
+
+      await expect(service.determineProgram(context)).rejects.toThrow(
+        'No se pudo determinar el programa para la solicitud',
+      );
+    });
+  });
+
+  describe('validateProgram', () => {
+    it('should return true when program exists and is active', async () => {
+      jest.spyOn(programCourseModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue({
+          programId: mockProgramId1,
+          isActive: true,
+        }),
+      } as any);
+
+      const result = await service.validateProgram(mockProgramId1);
+
+      expect(result).toBe(true);
+      expect(programCourseModel.findOne).toHaveBeenCalledWith({
+        programId: mockProgramId1,
+        isActive: true,
+      });
+    });
+
+    it('should return false when program not found', async () => {
+      jest.spyOn(programCourseModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      const result = await service.validateProgram('nonexistent');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when program is inactive', async () => {
+      jest.spyOn(programCourseModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      const result = await service.validateProgram(mockProgramId1);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false on database error', async () => {
+      jest.spyOn(programCourseModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockRejectedValue(new Error('Database error')),
+      } as any);
+
+      const result = await service.validateProgram(mockProgramId1);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getRoutingStats', () => {
+    it('should return all routing rules descriptions', () => {
+      const stats = service.getRoutingStats();
+
+      expect(stats).toHaveProperty('SAME_PROGRAM');
+      expect(stats).toHaveProperty('TARGET_PROGRAM');
+      expect(stats).toHaveProperty('SOURCE_PROGRAM');
+      expect(stats).toHaveProperty('STUDENT_PROGRAM');
+      expect(Object.keys(stats)).toHaveLength(4);
+    });
+
+    it('should have correct descriptions for each rule', () => {
+      const stats = service.getRoutingStats();
+
+      expect(stats['SAME_PROGRAM']).toBe('Ambas materias del mismo programa');
+      expect(stats['TARGET_PROGRAM']).toBe('Programa de materia destino');
+      expect(stats['SOURCE_PROGRAM']).toBe('Programa de materia origen');
+      expect(stats['STUDENT_PROGRAM']).toBe('Programa del estudiante (fallback)');
+    });
+  });
+
+  describe('Integration scenarios', () => {
+    it('should handle complete routing workflow', async () => {
+      const context: RoutingContext = {
+        userId: mockUserId,
+        sourceSubjectId: mockSourceSubjectId,
+        targetSubjectId: mockTargetSubjectId,
+        studentProgramId: mockStudentProgramId, // Proveer para evitar llamada a BD
+      };
+
+      jest.spyOn(programCourseModel, 'findOne').mockImplementation((query: any) => {
+        // Si el query tiene populate (llamada para determinar programa de materias)
+        if (query.courseId) {
+          return {
+            populate: jest.fn().mockReturnValue({
+              exec: jest.fn().mockResolvedValue({
+                courseId: query.courseId,
+                programId: mockProgramId1,
+              }),
+            }),
+          } as any;
+        }
+        // Si el query es para validateProgram
+        return {
+          exec: jest.fn().mockResolvedValue({
+            programId: mockProgramId1,
+            isActive: true,
+          }),
+        } as any;
+      });
+
+      const decision = await service.determineProgram(context);
+      const isValid = await service.validateProgram(decision.assignedProgramId);
+
+      expect(decision.assignedProgramId).toBe(mockProgramId1);
+      expect(isValid).toBe(true);
+    });
+
+    it('should handle all routing rules systematically', async () => {
+      const stats = service.getRoutingStats();
+      const rules = Object.keys(stats);
+
+      expect(rules).toContain('SAME_PROGRAM');
+      expect(rules).toContain('TARGET_PROGRAM');
+      expect(rules).toContain('SOURCE_PROGRAM');
+      expect(rules).toContain('STUDENT_PROGRAM');
+    });
+  });
+});

--- a/src/test/sanitizer.util.spec.ts
+++ b/src/test/sanitizer.util.spec.ts
@@ -1,0 +1,280 @@
+import { SanitizerUtil } from '../common/utils/sanitizer.util';
+
+describe('SanitizerUtil', () => {
+  describe('sanitizeObservations', () => {
+    it('should return null for empty string', () => {
+      expect(SanitizerUtil.sanitizeObservations('')).toBeNull();
+    });
+
+    it('should return null for null input', () => {
+      expect(SanitizerUtil.sanitizeObservations(null)).toBeNull();
+    });
+
+    it('should return null for undefined input', () => {
+      expect(SanitizerUtil.sanitizeObservations(undefined)).toBeNull();
+    });
+
+    it('should return null for whitespace-only string', () => {
+      expect(SanitizerUtil.sanitizeObservations('   ')).toBeNull();
+    });
+
+    it('should sanitize basic text without changes', () => {
+      const input = 'Esta es una observación normal.';
+      expect(SanitizerUtil.sanitizeObservations(input)).toBe(input);
+    });
+
+    it('should throw error for null bytes', () => {
+      const input = 'Texto con null byte\0aquí';
+      expect(() => SanitizerUtil.sanitizeObservations(input)).toThrow(
+        'La observación contiene caracteres null bytes no permitidos'
+      );
+    });
+
+    it('should throw error for hex null bytes', () => {
+      const input = 'Texto con\x00null byte';
+      expect(() => SanitizerUtil.sanitizeObservations(input)).toThrow(
+        'La observación contiene caracteres null bytes no permitidos'
+      );
+    });
+
+    it('should remove HTML tags', () => {
+      const input = '<script>alert("xss")</script>Texto normal';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).not.toContain('<script>');
+      expect(result).toContain('Texto normal');
+    });
+
+    it('should remove dangerous HTML attributes', () => {
+      const input = '<div onclick="malicious()">Texto</div>';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).not.toContain('onclick');
+      expect(result).toContain('Texto');
+    });
+
+    it('should preserve line breaks', () => {
+      const input = 'Línea 1\nLínea 2\nLínea 3';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toBe(input);
+    });
+
+    it('should normalize Windows line endings to Unix', () => {
+      const input = 'Línea 1\r\nLínea 2';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toBe('Línea 1\nLínea 2');
+    });
+
+    it('should normalize Mac line endings to Unix', () => {
+      const input = 'Línea 1\rLínea 2';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toBe('Línea 1\nLínea 2');
+    });
+
+    it('should limit consecutive line breaks to 2', () => {
+      const input = 'Línea 1\n\n\n\n\nLínea 2';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toBe('Línea 1\n\nLínea 2');
+    });
+
+    it('should trim leading and trailing whitespace', () => {
+      const input = '   Texto con espacios   ';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toBe('Texto con espacios');
+    });
+
+    it('should remove control characters except tab, newline, carriage return', () => {
+      const input = 'Texto\x01con\x02control\x03chars';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toBe('Textoconcontrolchars');
+    });
+
+    it('should preserve tabs', () => {
+      const input = 'Texto\tcon\ttabulaciones';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('\t');
+    });
+
+    it('should sanitize MongoDB $where operator', () => {
+      const input = 'Observación con $where injection';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).not.toContain('$where');
+      expect(result).toContain('&#36;where');
+    });
+
+    it('should sanitize MongoDB $ne operator', () => {
+      const input = 'Observación con $ne operator';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).not.toContain('$ne');
+      expect(result).toContain('&#36;ne');
+    });
+
+    it('should sanitize MongoDB $gt operator', () => {
+      const input = 'Observación con $gt operator';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;gt');
+    });
+
+    it('should sanitize MongoDB $gte operator', () => {
+      const input = 'Observación con $gte operator';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;gte');
+    });
+
+    it('should sanitize MongoDB $lt operator', () => {
+      const input = 'Observación con $lt operator';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;lt');
+    });
+
+    it('should sanitize MongoDB $lte operator', () => {
+      const input = 'Observación con $lte operator';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;lte');
+    });
+
+    it('should sanitize MongoDB $or operator', () => {
+      const input = 'Observación con $or operator';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;or');
+    });
+
+    it('should sanitize MongoDB $and operator', () => {
+      const input = 'Observación con $and operator';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;and');
+    });
+
+    it('should sanitize MongoDB $not operator', () => {
+      const input = 'Observación con $not operator';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;not');
+    });
+
+    it('should sanitize MongoDB $nor operator', () => {
+      const input = 'Observación con $nor operator';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;nor');
+    });
+
+    it('should sanitize MongoDB $exists operator', () => {
+      const input = 'Observación con $exists operator';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;exists');
+    });
+
+    it('should sanitize MongoDB $type operator', () => {
+      const input = 'Observación con $type operator';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;type');
+    });
+
+    it('should sanitize MongoDB $regex operator', () => {
+      const input = 'Observación con $regex operator';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;regex');
+    });
+
+    it('should sanitize MongoDB $expr operator', () => {
+      const input = 'Observación con $expr operator';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;expr');
+    });
+
+    it('should sanitize MongoDB $function operator', () => {
+      const input = 'Observación con $function operator';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;function');
+    });
+
+    it('should sanitize case-insensitive MongoDB operators', () => {
+      const input = 'Observación con $WHERE y $NE';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;where');
+      expect(result).toContain('&#36;ne');
+    });
+
+    it('should handle multiple MongoDB operators in one string', () => {
+      const input = 'Injection con $where y $or y $gt';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('&#36;where');
+      expect(result).toContain('&#36;or');
+      expect(result).toContain('&#36;gt');
+    });
+
+    it('should handle complex real-world observation', () => {
+      const input = `Estudiante destacado en matemáticas.
+Requiere apoyo en inglés.
+
+Observaciones adicionales:
+- Participa activamente
+- Buena asistencia`;
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toContain('Estudiante destacado');
+      expect(result).toContain('Requiere apoyo');
+      expect(result).toContain('Participa activamente');
+    });
+
+    it('should handle text with special characters', () => {
+      const input = 'Observación con áéíóú ñ ¿? ¡!';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toBe(input);
+    });
+
+    it('should return null after sanitization if only whitespace remains', () => {
+      const input = '   \n\n   ';
+      const result = SanitizerUtil.sanitizeObservations(input);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('validateLength', () => {
+    it('should return true for null input', () => {
+      expect(SanitizerUtil.validateLength(null)).toBe(true);
+    });
+
+    it('should return true for text within default length', () => {
+      const text = 'Esta es una observación corta.';
+      expect(SanitizerUtil.validateLength(text)).toBe(true);
+    });
+
+    it('should return true for text exactly at max length', () => {
+      const text = 'a'.repeat(2000);
+      expect(SanitizerUtil.validateLength(text, 2000)).toBe(true);
+    });
+
+    it('should return false for text exceeding max length', () => {
+      const text = 'a'.repeat(2001);
+      expect(SanitizerUtil.validateLength(text, 2000)).toBe(false);
+    });
+
+    it('should use custom max length', () => {
+      const text = 'a'.repeat(51);
+      expect(SanitizerUtil.validateLength(text, 50)).toBe(false);
+    });
+
+    it('should return true for empty string', () => {
+      expect(SanitizerUtil.validateLength('')).toBe(true);
+    });
+
+    it('should handle very long text correctly', () => {
+      const text = 'a'.repeat(5000);
+      expect(SanitizerUtil.validateLength(text, 2000)).toBe(false);
+      expect(SanitizerUtil.validateLength(text, 10000)).toBe(true);
+    });
+  });
+
+  describe('Integration: sanitize and validate together', () => {
+    it('should sanitize and then validate length', () => {
+      const input = '<script>alert("xss")</script>' + 'a'.repeat(1900);
+      const sanitized = SanitizerUtil.sanitizeObservations(input);
+      expect(sanitized).toBeDefined();
+      expect(SanitizerUtil.validateLength(sanitized!, 2000)).toBe(true);
+    });
+
+    it('should handle malicious input with length validation', () => {
+      const input = '$where attack with ' + 'a'.repeat(1900);
+      const sanitized = SanitizerUtil.sanitizeObservations(input);
+      expect(sanitized).toContain('&#36;where');
+      expect(SanitizerUtil.validateLength(sanitized!, 2000)).toBe(true);
+    });
+  });
+});

--- a/src/test/schedule-validation.service.spec.ts
+++ b/src/test/schedule-validation.service.spec.ts
@@ -1,0 +1,676 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { ScheduleValidationService } from '../schedules/services/schedule-validation.service';
+import {
+  GroupSchedule,
+  GroupScheduleDocument,
+} from '../group-schedules/entities/group-schedule.entity';
+import {
+  CourseGroup,
+  CourseGroupDocument,
+} from '../course-groups/entities/course-group.entity';
+import {
+  Enrollment,
+  EnrollmentDocument,
+  EnrollmentStatus,
+} from '../enrollments/entities/enrollment.entity';
+import {
+  AcademicPeriod,
+  AcademicPeriodDocument,
+} from '../academic-periods/entities/academic-period.entity';
+import { ValidationResult, TimeSlot } from '../schedules/interfaces/schedule.interface';
+
+describe('ScheduleValidationService', () => {
+  let service: ScheduleValidationService;
+  let groupScheduleModel: Model<GroupScheduleDocument>;
+  let courseGroupModel: Model<CourseGroupDocument>;
+  let enrollmentModel: Model<EnrollmentDocument>;
+  let academicPeriodModel: Model<AcademicPeriodDocument>;
+
+  const mockStudentId = '60d5ecb8b0a7c4b4b8b9b1a1';
+  const mockSourceGroupId = '60d5ecb8b0a7c4b4b8b9b1a2';
+  const mockTargetGroupId = '60d5ecb8b0a7c4b4b8b9b1a3';
+  const mockCourseId = '60d5ecb8b0a7c4b4b8b9b1a4';
+  const mockPeriodId = '60d5ecb8b0a7c4b4b8b9b1a5';
+
+  const mockActivePeriod = {
+    _id: mockPeriodId,
+    code: '2024-2',
+    name: 'Segundo Semestre 2024',
+    isActive: true,
+    allowChangeRequests: true,
+    status: 'ACTIVE',
+  };
+
+  const mockSourceGroup = {
+    _id: mockSourceGroupId,
+    courseId: mockCourseId,
+    periodId: mockPeriodId,
+    groupNumber: 'A',
+    maxStudents: 30,
+    currentEnrollments: 20,
+  };
+
+  const mockTargetGroup = {
+    _id: mockTargetGroupId,
+    courseId: mockCourseId,
+    periodId: mockPeriodId,
+    groupNumber: 'B',
+    maxStudents: 30,
+    currentEnrollments: 15,
+  };
+
+  const mockEnrollment = {
+    _id: '60d5ecb8b0a7c4b4b8b9b1a6',
+    studentId: mockStudentId,
+    groupId: mockSourceGroupId,
+    status: EnrollmentStatus.ENROLLED,
+  };
+
+  const mockSchedule1 = {
+    _id: '60d5ecb8b0a7c4b4b8b9b1a7',
+    groupId: mockSourceGroupId,
+    dayOfWeek: 1, // Monday
+    startTime: '08:00',
+    endTime: '10:00',
+    room: 'Aula 101',
+  };
+
+  const mockSchedule2 = {
+    _id: '60d5ecb8b0a7c4b4b8b9b1a8',
+    groupId: mockTargetGroupId,
+    dayOfWeek: 1, // Monday
+    startTime: '10:00',
+    endTime: '12:00',
+    room: 'Aula 102',
+  };
+
+  const mockGroupScheduleModel = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    findById: jest.fn(),
+    create: jest.fn(),
+  };
+
+  const mockCourseGroupModel = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    findById: jest.fn(),
+  };
+
+  const mockEnrollmentModel = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    countDocuments: jest.fn(),
+  };
+
+  const mockAcademicPeriodModel = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    findById: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ScheduleValidationService,
+        {
+          provide: getModelToken(GroupSchedule.name),
+          useValue: mockGroupScheduleModel,
+        },
+        {
+          provide: getModelToken(CourseGroup.name),
+          useValue: mockCourseGroupModel,
+        },
+        {
+          provide: getModelToken(Enrollment.name),
+          useValue: mockEnrollmentModel,
+        },
+        {
+          provide: getModelToken(AcademicPeriod.name),
+          useValue: mockAcademicPeriodModel,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ScheduleValidationService>(ScheduleValidationService);
+    groupScheduleModel = module.get<Model<GroupScheduleDocument>>(
+      getModelToken(GroupSchedule.name),
+    );
+    courseGroupModel = module.get<Model<CourseGroupDocument>>(
+      getModelToken(CourseGroup.name),
+    );
+    enrollmentModel = module.get<Model<EnrollmentDocument>>(
+      getModelToken(Enrollment.name),
+    );
+    academicPeriodModel = module.get<Model<AcademicPeriodDocument>>(
+      getModelToken(AcademicPeriod.name),
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('validateActivePeriod', () => {
+    it('should return valid when active period exists and allows change requests', async () => {
+      const execChain = {
+        exec: jest.fn().mockResolvedValue(mockActivePeriod),
+      };
+      (academicPeriodModel.findOne as jest.Mock).mockReturnValue(execChain);
+
+      const result = await service.validateActivePeriod();
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(academicPeriodModel.findOne).toHaveBeenCalledWith({
+        isActive: true,
+        allowChangeRequests: true,
+      });
+    });
+
+    it('should return invalid when no active period exists', async () => {
+      const execChain = {
+        exec: jest.fn().mockResolvedValue(null),
+      };
+      (academicPeriodModel.findOne as jest.Mock).mockReturnValue(execChain);
+
+      const result = await service.validateActivePeriod();
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('No active academic period that allows change requests');
+    });
+  });
+
+  describe('validateAvailableSpots', () => {
+    it('should return valid when group has available spots', async () => {
+      const execChain = {
+        exec: jest.fn().mockResolvedValue(mockTargetGroup),
+      };
+      (courseGroupModel.findById as jest.Mock).mockReturnValue(execChain);
+
+      const countChain = {
+        exec: jest.fn().mockResolvedValue(15),
+      };
+      (enrollmentModel.countDocuments as jest.Mock).mockReturnValue(countChain);
+
+      const result = await service.validateAvailableSpots(mockTargetGroupId);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should return invalid when group is full', async () => {
+      const execChain = {
+        exec: jest.fn().mockResolvedValue(mockTargetGroup),
+      };
+      (courseGroupModel.findById as jest.Mock).mockReturnValue(execChain);
+
+      const countChain = {
+        exec: jest.fn().mockResolvedValue(30),
+      };
+      (enrollmentModel.countDocuments as jest.Mock).mockReturnValue(countChain);
+
+      const result = await service.validateAvailableSpots(mockTargetGroupId);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('Target group has no available spots');
+    });
+
+    it('should return warning when group is near capacity', async () => {
+      const execChain = {
+        exec: jest.fn().mockResolvedValue(mockTargetGroup),
+      };
+      (courseGroupModel.findById as jest.Mock).mockReturnValue(execChain);
+
+      const countChain = {
+        exec: jest.fn().mockResolvedValue(27), // 90% of 30
+      };
+      (enrollmentModel.countDocuments as jest.Mock).mockReturnValue(countChain);
+
+      const result = await service.validateAvailableSpots(mockTargetGroupId);
+
+      expect(result.isValid).toBe(true);
+      expect(result.warnings).toContain('Target group is near capacity limit');
+    });
+
+    it('should return invalid when group not found', async () => {
+      const execChain = {
+        exec: jest.fn().mockResolvedValue(null),
+      };
+      (courseGroupModel.findById as jest.Mock).mockReturnValue(execChain);
+
+      const result = await service.validateAvailableSpots(mockTargetGroupId);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('Group not found');
+    });
+  });
+
+  describe('validateStudentEnrollment', () => {
+    it('should return valid when student is enrolled in source group', async () => {
+      const execChain = {
+        exec: jest.fn().mockResolvedValue(mockEnrollment),
+      };
+      (enrollmentModel.findOne as jest.Mock).mockReturnValue(execChain);
+
+      const result = await service.validateStudentEnrollment(mockStudentId, mockSourceGroupId);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(enrollmentModel.findOne).toHaveBeenCalledWith({
+        studentId: mockStudentId,
+        groupId: mockSourceGroupId,
+        status: EnrollmentStatus.ENROLLED,
+      });
+    });
+
+    it('should return invalid when student is not enrolled', async () => {
+      const execChain = {
+        exec: jest.fn().mockResolvedValue(null),
+      };
+      (enrollmentModel.findOne as jest.Mock).mockReturnValue(execChain);
+
+      const result = await service.validateStudentEnrollment(mockStudentId, mockSourceGroupId);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('Student is not enrolled in the source group');
+    });
+  });
+
+  describe('validateSameCourse', () => {
+    it('should return valid when groups are from same course and period', async () => {
+      const sourceExec = {
+        exec: jest.fn().mockResolvedValue(mockSourceGroup),
+      };
+      const targetExec = {
+        exec: jest.fn().mockResolvedValue(mockTargetGroup),
+      };
+      
+      (courseGroupModel.findById as jest.Mock)
+        .mockReturnValueOnce(sourceExec)
+        .mockReturnValueOnce(targetExec);
+
+      const result = await service.validateSameCourse(mockSourceGroupId, mockTargetGroupId);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should return invalid when groups are from different courses', async () => {
+      const differentCourseGroup = {
+        ...mockTargetGroup,
+        courseId: 'different-course-id',
+      };
+      
+      const sourceExec = {
+        exec: jest.fn().mockResolvedValue(mockSourceGroup),
+      };
+      const targetExec = {
+        exec: jest.fn().mockResolvedValue(differentCourseGroup),
+      };
+      
+      (courseGroupModel.findById as jest.Mock)
+        .mockReturnValueOnce(sourceExec)
+        .mockReturnValueOnce(targetExec);
+
+      const result = await service.validateSameCourse(mockSourceGroupId, mockTargetGroupId);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('Groups must be from the same course');
+    });
+
+    it('should return invalid when groups are from different periods', async () => {
+      const differentPeriodGroup = {
+        ...mockTargetGroup,
+        periodId: 'different-period-id',
+      };
+      
+      const sourceExec = {
+        exec: jest.fn().mockResolvedValue(mockSourceGroup),
+      };
+      const targetExec = {
+        exec: jest.fn().mockResolvedValue(differentPeriodGroup),
+      };
+      
+      (courseGroupModel.findById as jest.Mock)
+        .mockReturnValueOnce(sourceExec)
+        .mockReturnValueOnce(targetExec);
+
+      const result = await service.validateSameCourse(mockSourceGroupId, mockTargetGroupId);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('Groups must be from the same academic period');
+    });
+
+    it('should return invalid when source group does not exist', async () => {
+      const sourceExec = {
+        exec: jest.fn().mockResolvedValue(null),
+      };
+      const targetExec = {
+        exec: jest.fn().mockResolvedValue(mockTargetGroup),
+      };
+      
+      (courseGroupModel.findById as jest.Mock)
+        .mockReturnValueOnce(sourceExec)
+        .mockReturnValueOnce(targetExec);
+
+      const result = await service.validateSameCourse(mockSourceGroupId, mockTargetGroupId);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('One or both groups do not exist');
+    });
+  });
+
+  describe('validateScheduleConflicts', () => {
+    it('should return valid when no schedule conflicts exist', async () => {
+      const enrollExec = {
+        exec: jest.fn().mockResolvedValue([]),
+      };
+      (enrollmentModel.find as jest.Mock).mockReturnValue(enrollExec);
+
+      const scheduleExec = {
+        exec: jest.fn().mockResolvedValue([mockSchedule2]),
+      };
+      (groupScheduleModel.find as jest.Mock).mockReturnValue(scheduleExec);
+
+      const result = await service.validateScheduleConflicts(
+        mockStudentId,
+        mockSourceGroupId,
+        mockTargetGroupId,
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should return invalid when schedule conflicts exist', async () => {
+      const otherEnrollment = {
+        _id: 'other-enrollment',
+        studentId: mockStudentId,
+        groupId: 'other-group-id',
+        status: EnrollmentStatus.ENROLLED,
+      };
+
+      const enrollExec = {
+        exec: jest.fn().mockResolvedValue([otherEnrollment]),
+      };
+      (enrollmentModel.find as jest.Mock).mockReturnValue(enrollExec);
+
+      const conflictingSchedule = {
+        ...mockSchedule2,
+        startTime: '08:30', // Overlaps with mockSchedule1
+        endTime: '10:30',
+      };
+
+      (groupScheduleModel.find as jest.Mock)
+        .mockReturnValueOnce({ exec: jest.fn().mockResolvedValue([mockSchedule1]) })
+        .mockReturnValueOnce({ exec: jest.fn().mockResolvedValue([conflictingSchedule]) });
+
+      const result = await service.validateScheduleConflicts(
+        mockStudentId,
+        mockSourceGroupId,
+        mockTargetGroupId,
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toContain('Schedule conflict');
+    });
+  });
+
+  describe('validateChangeRequest', () => {
+    it('should return valid when all validations pass', async () => {
+      // Mock validateActivePeriod
+      const periodExec = {
+        exec: jest.fn().mockResolvedValue(mockActivePeriod),
+      };
+      (academicPeriodModel.findOne as jest.Mock).mockReturnValue(periodExec);
+
+      // Mock validateAvailableSpots
+      const groupExec = {
+        exec: jest.fn().mockResolvedValue(mockTargetGroup),
+      };
+      (courseGroupModel.findById as jest.Mock).mockReturnValue(groupExec);
+
+      const countExec = {
+        exec: jest.fn().mockResolvedValue(15),
+      };
+      (enrollmentModel.countDocuments as jest.Mock).mockReturnValue(countExec);
+
+      // Mock validateScheduleConflicts
+      const enrollExec = {
+        exec: jest.fn().mockResolvedValue([]),
+      };
+      (enrollmentModel.find as jest.Mock).mockReturnValue(enrollExec);
+
+      const scheduleExec = {
+        exec: jest.fn().mockResolvedValue([mockSchedule2]),
+      };
+      (groupScheduleModel.find as jest.Mock).mockReturnValue(scheduleExec);
+
+      // Mock validateStudentEnrollment
+      (enrollmentModel.findOne as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockEnrollment),
+      });
+
+      // Mock validateSameCourse
+      (courseGroupModel.findById as jest.Mock)
+        .mockReturnValueOnce({ exec: jest.fn().mockResolvedValue(mockSourceGroup) })
+        .mockReturnValueOnce({ exec: jest.fn().mockResolvedValue(mockTargetGroup) });
+
+      const result = await service.validateChangeRequest(
+        mockStudentId,
+        mockSourceGroupId,
+        mockTargetGroupId,
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should return invalid when any validation fails', async () => {
+      // Mock validateActivePeriod to fail
+      const periodExec = {
+        exec: jest.fn().mockResolvedValue(null),
+      };
+      (academicPeriodModel.findOne as jest.Mock).mockReturnValue(periodExec);
+
+      const result = await service.validateChangeRequest(
+        mockStudentId,
+        mockSourceGroupId,
+        mockTargetGroupId,
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should handle validation errors gracefully', async () => {
+      (academicPeriodModel.findOne as jest.Mock).mockReturnValue({
+        exec: jest.fn().mockRejectedValue(new Error('Database error')),
+      });
+
+      const result = await service.validateChangeRequest(
+        mockStudentId,
+        mockSourceGroupId,
+        mockTargetGroupId,
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors[0]).toContain('Validation error');
+    });
+  });
+
+  describe('detectScheduleConflicts', () => {
+    it('should detect overlapping classes on same day', async () => {
+      const schedule = [
+        {
+          dayOfWeek: 1,
+          dayName: 'Lunes',
+          classes: [
+            {
+              courseCode: 'MAT101',
+              courseName: 'Matemáticas I',
+              groupNumber: 'A',
+              startTime: '08:00',
+              endTime: '10:00',
+              room: 'Aula 101',
+            },
+            {
+              courseCode: 'FIS101',
+              courseName: 'Física I',
+              groupNumber: 'B',
+              startTime: '09:00',
+              endTime: '11:00',
+              room: 'Aula 102',
+            },
+          ],
+        },
+      ];
+
+      const conflicts = await service.detectScheduleConflicts(schedule);
+
+      expect(conflicts).toHaveLength(1);
+      expect(conflicts[0].day).toBe('Lunes');
+      expect(conflicts[0].conflictType).toBe('overlap');
+      expect(conflicts[0].course1.code).toBe('MAT101');
+      expect(conflicts[0].course2.code).toBe('FIS101');
+    });
+
+    it('should not detect conflicts for non-overlapping classes', async () => {
+      const schedule = [
+        {
+          dayOfWeek: 1,
+          dayName: 'Lunes',
+          classes: [
+            {
+              courseCode: 'MAT101',
+              courseName: 'Matemáticas I',
+              groupNumber: 'A',
+              startTime: '08:00',
+              endTime: '10:00',
+            },
+            {
+              courseCode: 'FIS101',
+              courseName: 'Física I',
+              groupNumber: 'B',
+              startTime: '10:00',
+              endTime: '12:00',
+            },
+          ],
+        },
+      ];
+
+      const conflicts = await service.detectScheduleConflicts(schedule);
+
+      expect(conflicts).toHaveLength(0);
+    });
+
+    it('should handle empty schedule', async () => {
+      const schedule = [
+        {
+          dayOfWeek: 1,
+          dayName: 'Lunes',
+          classes: [],
+        },
+      ];
+
+      const conflicts = await service.detectScheduleConflicts(schedule);
+
+      expect(conflicts).toHaveLength(0);
+    });
+
+    it('should handle single class on day', async () => {
+      const schedule = [
+        {
+          dayOfWeek: 1,
+          dayName: 'Lunes',
+          classes: [
+            {
+              courseCode: 'MAT101',
+              courseName: 'Matemáticas I',
+              groupNumber: 'A',
+              startTime: '08:00',
+              endTime: '10:00',
+            },
+          ],
+        },
+      ];
+
+      const conflicts = await service.detectScheduleConflicts(schedule);
+
+      expect(conflicts).toHaveLength(0);
+    });
+  });
+
+  describe('validateClosedPeriod', () => {
+    it('should return true when period is closed', async () => {
+      const closedPeriod = {
+        ...mockActivePeriod,
+        status: 'CLOSED',
+      };
+      
+      const execChain = {
+        exec: jest.fn().mockResolvedValue(closedPeriod),
+      };
+      (academicPeriodModel.findById as jest.Mock).mockReturnValue(execChain);
+
+      const result = await service.validateClosedPeriod(mockPeriodId);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when period is not closed', async () => {
+      const execChain = {
+        exec: jest.fn().mockResolvedValue(mockActivePeriod),
+      };
+      (academicPeriodModel.findById as jest.Mock).mockReturnValue(execChain);
+
+      const result = await service.validateClosedPeriod(mockPeriodId);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when period not found', async () => {
+      const execChain = {
+        exec: jest.fn().mockResolvedValue(null),
+      };
+      (academicPeriodModel.findById as jest.Mock).mockReturnValue(execChain);
+
+      const result = await service.validateClosedPeriod(mockPeriodId);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getGroupSchedule', () => {
+    it('should return formatted time slots for group', async () => {
+      const execChain = {
+        exec: jest.fn().mockResolvedValue([mockSchedule1, mockSchedule2]),
+      };
+      (groupScheduleModel.find as jest.Mock).mockReturnValue(execChain);
+
+      const result = await service.getGroupSchedule(mockSourceGroupId);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toHaveProperty('dayOfWeek');
+      expect(result[0]).toHaveProperty('startTime');
+      expect(result[0]).toHaveProperty('endTime');
+      expect(result[0]).toHaveProperty('groupId');
+      expect(result[0].groupId).toBe(mockSourceGroupId);
+    });
+
+    it('should return empty array when no schedules exist', async () => {
+      const execChain = {
+        exec: jest.fn().mockResolvedValue([]),
+      };
+      (groupScheduleModel.find as jest.Mock).mockReturnValue(execChain);
+
+      const result = await service.getGroupSchedule(mockSourceGroupId);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/src/test/students.controller.spec.ts
+++ b/src/test/students.controller.spec.ts
@@ -1,0 +1,445 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StudentsController } from '../students/students.controller';
+import { StudentsService } from '../students/services/students.service';
+import { CreateStudentDto } from '../students/dto/create-student.dto';
+import { UpdateStudentDto } from '../students/dto/update-student.dto';
+
+describe('StudentsController', () => {
+  let controller: StudentsController;
+  let service: StudentsService;
+
+  const mockStudent = {
+    _id: '507f1f77bcf86cd799439011',
+    code: 'EST001',
+    firstName: 'Juan',
+    lastName: 'Pérez',
+    fullName: 'Juan Pérez',
+    programId: '507f1f77bcf86cd799439012',
+    externalId: 'ext-001',
+    currentSemester: 5,
+    email: 'juan.perez@universidad.edu',
+    phone: '+57 300 123 4567',
+    observations: 'Estudiante destacado',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockStudentsService = {
+    create: jest.fn().mockResolvedValue(mockStudent),
+    findAll: jest.fn().mockResolvedValue([mockStudent]),
+    findOne: jest.fn().mockResolvedValue(mockStudent),
+    findByCode: jest.fn().mockResolvedValue(mockStudent),
+    update: jest.fn().mockResolvedValue({ ...mockStudent, currentSemester: 6 }),
+    remove: jest.fn().mockResolvedValue({ deleted: true }),
+    getStudentSchedule: jest.fn().mockResolvedValue({
+      studentCode: 'EST001',
+      schedule: [],
+    }),
+    getStudentAcademicHistory: jest.fn().mockResolvedValue({
+      studentCode: 'EST001',
+      history: [],
+    }),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StudentsController],
+      providers: [
+        {
+          provide: StudentsService,
+          useValue: mockStudentsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<StudentsController>(StudentsController);
+    service = module.get<StudentsService>(StudentsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a new student', async () => {
+      const createDto: CreateStudentDto = {
+        code: 'EST001',
+        firstName: 'Juan',
+        lastName: 'Pérez',
+        programId: '507f1f77bcf86cd799439012',
+        currentSemester: 1,
+      };
+
+      const result = await controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledWith(createDto);
+      expect(result).toEqual(mockStudent);
+    });
+
+    it('should create a student with optional fields', async () => {
+      const createDto: CreateStudentDto = {
+        code: 'EST002',
+        firstName: 'Maria',
+        lastName: 'García',
+        programId: '507f1f77bcf86cd799439012',
+        email: 'maria.garcia@universidad.edu',
+        phone: '+57 300 987 6543',
+        currentSemester: 3,
+        observations: 'Estudiante de intercambio',
+      };
+
+      const result = await controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledWith(createDto);
+      expect(result).toEqual(mockStudent);
+    });
+
+    it('should create a student with minimal required fields', async () => {
+      const createDto: CreateStudentDto = {
+        code: 'EST003',
+        firstName: 'Carlos',
+        lastName: 'Martínez',
+        programId: '507f1f77bcf86cd799439012',
+      };
+
+      const result = await controller.create(createDto);
+
+      expect(service.create).toHaveBeenCalledWith(createDto);
+      expect(result).toEqual(mockStudent);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of students', async () => {
+      const result = await controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toEqual([mockStudent]);
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('should return empty array when no students exist', async () => {
+      mockStudentsService.findAll.mockResolvedValueOnce([]);
+
+      const result = await controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single student by ID', async () => {
+      const id = '507f1f77bcf86cd799439011';
+      const result = await controller.findOne(id);
+
+      expect(service.findOne).toHaveBeenCalledWith(id);
+      expect(result).toEqual(mockStudent);
+    });
+
+    it('should handle different student IDs', async () => {
+      const id = '507f1f77bcf86cd799439099';
+      const differentStudent = { ...mockStudent, _id: id, code: 'EST999' };
+      mockStudentsService.findOne.mockResolvedValueOnce(differentStudent);
+
+      const result = await controller.findOne(id);
+
+      expect(service.findOne).toHaveBeenCalledWith(id);
+      expect(result._id).toBe(id);
+    });
+  });
+
+  describe('findByCode', () => {
+    it('should return a student by code', async () => {
+      const studentCode = 'EST001';
+      const result = await controller.findByCode(studentCode);
+
+      expect(service.findByCode).toHaveBeenCalledWith(studentCode);
+      expect(result).toEqual(mockStudent);
+    });
+
+    it('should handle different student codes', async () => {
+      const studentCode = 'ENG2024001';
+      const differentStudent = { ...mockStudent, code: studentCode };
+      mockStudentsService.findByCode.mockResolvedValueOnce(differentStudent);
+
+      const result = await controller.findByCode(studentCode);
+
+      expect(service.findByCode).toHaveBeenCalledWith(studentCode);
+      expect(result.code).toBe(studentCode);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a student', async () => {
+      const id = '507f1f77bcf86cd799439011';
+      const updateDto: UpdateStudentDto = {
+        currentSemester: 6,
+      };
+
+      const result = await controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(id, updateDto);
+      expect(result).toEqual({ ...mockStudent, currentSemester: 6 });
+    });
+
+    it('should update student name', async () => {
+      const id = '507f1f77bcf86cd799439011';
+      const updateDto: UpdateStudentDto = {
+        firstName: 'Juan Carlos',
+        lastName: 'Pérez García',
+      };
+
+      const updatedStudent = {
+        ...mockStudent,
+        firstName: 'Juan Carlos',
+        lastName: 'Pérez García',
+        fullName: 'Juan Carlos Pérez García',
+      };
+      mockStudentsService.update.mockResolvedValueOnce(updatedStudent);
+
+      const result = await controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(id, updateDto);
+      expect(result.firstName).toBe('Juan Carlos');
+      expect(result.lastName).toBe('Pérez García');
+    });
+
+    it('should transfer student to different program', async () => {
+      const id = '507f1f77bcf86cd799439011';
+      const newProgramId = '507f1f77bcf86cd799439099';
+      const updateDto: UpdateStudentDto = {
+        programId: newProgramId,
+      };
+
+      const updatedStudent = { ...mockStudent, programId: newProgramId };
+      mockStudentsService.update.mockResolvedValueOnce(updatedStudent);
+
+      const result = await controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(id, updateDto);
+      expect(result.programId).toBe(newProgramId);
+    });
+
+    it('should update student observations', async () => {
+      const id = '507f1f77bcf86cd799439011';
+      const updateDto: UpdateStudentDto = {
+        observations: 'Observaciones actualizadas',
+      };
+
+      const result = await controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(id, updateDto);
+      expect(result).toBeDefined();
+    });
+
+    it('should update multiple fields at once', async () => {
+      const id = '507f1f77bcf86cd799439011';
+      const updateDto: UpdateStudentDto = {
+        currentSemester: 7,
+        email: 'nuevo.email@universidad.edu',
+        phone: '+57 300 999 8888',
+      };
+
+      const result = await controller.update(id, updateDto);
+
+      expect(service.update).toHaveBeenCalledWith(id, updateDto);
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a student', async () => {
+      const id = '507f1f77bcf86cd799439011';
+      const result = await controller.remove(id);
+
+      expect(service.remove).toHaveBeenCalledWith(id);
+      expect(result).toEqual({ deleted: true });
+    });
+
+    it('should handle deletion of different students', async () => {
+      const id = '507f1f77bcf86cd799439099';
+      const result = await controller.remove(id);
+
+      expect(service.remove).toHaveBeenCalledWith(id);
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('getSchedule', () => {
+    it('should return student schedule', async () => {
+      const studentCode = 'EST001';
+      const mockSchedule = {
+        studentId: 'EST001',
+        schedule: [
+          {
+            courseCode: 'MAT101',
+            courseName: 'Matemáticas I',
+            group: 'A',
+            schedule: 'Lunes 8:00-10:00',
+          },
+        ],
+      };
+      mockStudentsService.getStudentSchedule.mockResolvedValueOnce(mockSchedule);
+
+      const result = await controller.getSchedule(studentCode);
+
+      expect(service.getStudentSchedule).toHaveBeenCalledWith(studentCode);
+      expect(result).toEqual(mockSchedule);
+    });
+
+    it('should return empty schedule for student with no enrollments', async () => {
+      const studentCode = 'EST999';
+      const emptySchedule = {
+        studentId: 'EST999',
+        schedule: [],
+      };
+      mockStudentsService.getStudentSchedule.mockResolvedValueOnce(emptySchedule);
+
+      const result = await controller.getSchedule(studentCode);
+
+      expect(service.getStudentSchedule).toHaveBeenCalledWith(studentCode);
+      expect(result.schedule).toEqual([]);
+    });
+  });
+
+  describe('getAcademicHistory', () => {
+    it('should return student academic history', async () => {
+      const studentCode = 'EST001';
+      const mockHistory = {
+        studentId: 'EST001',
+        periods: [
+          {
+            period: '2024-1',
+            courses: [
+              { code: 'MAT101', name: 'Matemáticas I', grade: 4.5 },
+            ],
+          },
+        ],
+      };
+      mockStudentsService.getStudentAcademicHistory.mockResolvedValueOnce(mockHistory);
+
+      const result = await controller.getAcademicHistory(studentCode);
+
+      expect(service.getStudentAcademicHistory).toHaveBeenCalledWith(studentCode);
+      expect(result).toEqual(mockHistory);
+    });
+
+    it('should return empty history for new student', async () => {
+      const studentCode = 'EST999';
+      const emptyHistory = {
+        studentId: 'EST999',
+        periods: [],
+      };
+      mockStudentsService.getStudentAcademicHistory.mockResolvedValueOnce(emptyHistory);
+
+      const result = await controller.getAcademicHistory(studentCode);
+
+      expect(service.getStudentAcademicHistory).toHaveBeenCalledWith(studentCode);
+      expect(result).toBeDefined();
+    });
+  });
+
+  // Integration scenarios
+  describe('Integration: Complete student lifecycle', () => {
+    it('should create, retrieve, update and delete a student', async () => {
+      const createDto: CreateStudentDto = {
+        code: 'EST001',
+        firstName: 'Juan',
+        lastName: 'Pérez',
+        programId: '507f1f77bcf86cd799439012',
+        currentSemester: 1,
+      };
+
+      // Create
+      const created = await controller.create(createDto);
+      expect(created).toEqual(mockStudent);
+
+      // Find by ID
+      const foundById = await controller.findOne(mockStudent._id as string);
+      expect(foundById).toEqual(mockStudent);
+
+      // Find by code
+      const foundByCode = await controller.findByCode(mockStudent.code);
+      expect(foundByCode).toEqual(mockStudent);
+
+      // Update
+      const updateDto: UpdateStudentDto = { currentSemester: 6 };
+      const updated = await controller.update(mockStudent._id as string, updateDto);
+      expect(updated).toBeDefined();
+
+      // Delete
+      const deleted = await controller.remove(mockStudent._id as string);
+      expect(deleted).toEqual({ deleted: true });
+    });
+  });
+
+  describe('Integration: Student academic tracking', () => {
+    it('should track student through enrollment and schedule', async () => {
+      const studentCode = 'EST001';
+
+      // Get student by code
+      const student = await controller.findByCode(studentCode);
+      expect(student.code).toBe(studentCode);
+
+      // Get schedule
+      const schedule = await controller.getSchedule(studentCode);
+      expect(schedule).toBeDefined();
+
+      // Get academic history
+      const history = await controller.getAcademicHistory(studentCode);
+      expect(history).toBeDefined();
+    });
+  });
+
+  describe('Integration: Student progression workflow', () => {
+    it('should manage student semester progression', async () => {
+      const studentId = mockStudent._id as string;
+
+      // Initial state
+      const student = await controller.findOne(studentId);
+      expect(student.currentSemester).toBe(5);
+
+      // Advance to next semester
+      const updateDto: UpdateStudentDto = { currentSemester: 6 };
+      const updated = await controller.update(studentId, updateDto);
+      expect(updated.currentSemester).toBe(6);
+
+      // Verify update
+      expect(service.update).toHaveBeenCalledWith(studentId, updateDto);
+    });
+  });
+
+  describe('Integration: Student program transfer', () => {
+    it('should transfer student between programs', async () => {
+      const studentId = mockStudent._id as string;
+      const originalProgramId = mockStudent.programId;
+      const newProgramId = '507f1f77bcf86cd799439099';
+
+      // Initial state
+      const student = await controller.findOne(studentId);
+      expect(student.programId).toBe(originalProgramId);
+
+      // Transfer to new program
+      const updateDto: UpdateStudentDto = {
+        programId: newProgramId,
+        currentSemester: 1, // Reset semester for new program
+      };
+
+      const transferredStudent = {
+        ...mockStudent,
+        programId: newProgramId,
+        currentSemester: 1,
+      };
+      mockStudentsService.update.mockResolvedValueOnce(transferredStudent);
+
+      const updated = await controller.update(studentId, updateDto);
+      expect(updated.programId).toBe(newProgramId);
+      expect(updated.currentSemester).toBe(1);
+    });
+  });
+});

--- a/src/test/students.service.spec.ts
+++ b/src/test/students.service.spec.ts
@@ -1,0 +1,309 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { NotFoundException, ConflictException } from '@nestjs/common';
+import { StudentsService } from '../students/services/students.service';
+import { Student, StudentDocument } from '../students/entities/student.entity';
+import { CreateStudentDto } from '../students/dto/create-student.dto';
+import { UpdateStudentDto } from '../students/dto/update-student.dto';
+import { StudentScheduleService } from '../schedules/services/student-schedule.service';
+
+describe('StudentsService', () => {
+  let service: StudentsService;
+  let studentModel: any;
+  let studentScheduleService: StudentScheduleService;
+
+  const mockStudentId = '60d5ecb8b0a7c4b4b8b9b1a1';
+  const mockStudent = {
+    _id: mockStudentId,
+    code: 'STU001',
+    firstName: 'Juan',
+    lastName: 'Pérez',
+    fullName: 'Juan Pérez',
+    programId: 'program123',
+    currentSemester: 5,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    save: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    // Create fresh mocks for each test
+    const mockStudentModel: any = jest.fn().mockImplementation((dto) => ({
+      ...dto,
+      save: jest.fn().mockResolvedValue({ 
+        ...dto, 
+        _id: mockStudentId,
+        fullName: `${dto.firstName} ${dto.lastName}`,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    }));
+    
+    // Don't set default mock values - let each test set them explicitly
+    mockStudentModel.findOne = jest.fn();
+    mockStudentModel.find = jest.fn();
+    mockStudentModel.findById = jest.fn();
+    mockStudentModel.findByIdAndUpdate = jest.fn();
+    mockStudentModel.findByIdAndDelete = jest.fn();
+
+    const mockStudentScheduleService = {
+      getCurrentSchedule: jest.fn(),
+      getStudentAcademicHistory: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StudentsService,
+        {
+          provide: getModelToken(Student.name),
+          useValue: mockStudentModel,
+        },
+        {
+          provide: StudentScheduleService,
+          useValue: mockStudentScheduleService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<StudentsService>(StudentsService);
+    studentModel = module.get(getModelToken(Student.name));
+    studentScheduleService = module.get<StudentScheduleService>(
+      StudentScheduleService,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('create', () => {
+    const createDto: CreateStudentDto = {
+      code: 'STU001',
+      firstName: 'Juan',
+      lastName: 'Pérez',
+      programId: 'program123',
+      currentSemester: 1,
+    };
+
+    it('should throw ConflictException when student code already exists', async () => {
+      studentModel.findOne.mockReturnValueOnce({
+        exec: jest.fn().mockResolvedValue(mockStudent),
+      });
+
+      await expect(service.create(createDto)).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all students', async () => {
+      const students = [mockStudent];
+      studentModel.find.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(students),
+      });
+
+      const result = await service.findAll();
+
+      expect(studentModel.find).toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0].code).toBe('STU001');
+    });
+
+    it('should return empty array when no students exist', async () => {
+      studentModel.find.mockReturnValue({
+        exec: jest.fn().mockResolvedValue([]),
+      });
+
+      const result = await service.findAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a student by id', async () => {
+      studentModel.findById.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockStudent),
+      });
+
+      const result = await service.findOne(mockStudentId);
+
+      expect(studentModel.findById).toHaveBeenCalledWith(mockStudentId);
+      expect(result.code).toBe('STU001');
+    });
+
+    it('should throw NotFoundException when student not found', async () => {
+      studentModel.findById.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(service.findOne('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.findOne('nonexistent')).rejects.toThrow(
+        /Student with ID nonexistent not found/,
+      );
+    });
+  });
+
+  describe('findByCode', () => {
+    it('should return a student by code', async () => {
+      studentModel.findOne.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockStudent),
+      });
+
+      const result = await service.findByCode('STU001');
+
+      expect(studentModel.findOne).toHaveBeenCalledWith({ code: 'STU001' });
+      expect(result.code).toBe('STU001');
+    });
+
+    it('should throw NotFoundException when student code not found', async () => {
+      studentModel.findOne.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(service.findByCode('NONEXISTENT')).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.findByCode('NONEXISTENT')).rejects.toThrow(
+        /Student with code NONEXISTENT not found/,
+      );
+    });
+  });
+
+  describe('update', () => {
+    const updateDto: UpdateStudentDto = {
+      firstName: 'Juan Carlos',
+      currentSemester: 6,
+    };
+
+    it('should update a student successfully', async () => {
+      const updatedStudent = { ...mockStudent, ...updateDto };
+      studentModel.findByIdAndUpdate.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(updatedStudent),
+      });
+
+      const result = await service.update(mockStudentId, updateDto);
+
+      expect(studentModel.findByIdAndUpdate).toHaveBeenCalledWith(
+        mockStudentId,
+        updateDto,
+        { new: true },
+      );
+      expect(result.firstName).toBe('Juan Carlos');
+      expect(result.currentSemester).toBe(6);
+    });
+
+    it('should throw NotFoundException when student not found', async () => {
+      studentModel.findByIdAndUpdate.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(service.update('nonexistent', updateDto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should allow partial updates', async () => {
+      const partialUpdate = { firstName: 'Pedro' };
+      const updatedStudent = { ...mockStudent, firstName: 'Pedro' };
+
+      studentModel.findByIdAndUpdate.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(updatedStudent),
+      });
+
+      const result = await service.update(mockStudentId, partialUpdate);
+
+      expect(result.firstName).toBe('Pedro');
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a student successfully', async () => {
+      studentModel.findByIdAndDelete.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockStudent),
+      });
+
+      await service.remove(mockStudentId);
+
+      expect(studentModel.findByIdAndDelete).toHaveBeenCalledWith(mockStudentId);
+    });
+
+    it('should throw NotFoundException when student not found', async () => {
+      studentModel.findByIdAndDelete.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(service.remove('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('getStudentSchedule', () => {
+    it('should return student schedule', async () => {
+      const mockSchedule = {
+        studentCode: 'STU001',
+        courses: [],
+      };
+
+      (studentScheduleService.getCurrentSchedule as jest.Mock).mockResolvedValue(
+        mockSchedule,
+      );
+
+      const result = await service.getStudentSchedule('STU001');
+
+      expect(studentScheduleService.getCurrentSchedule).toHaveBeenCalledWith(
+        'STU001',
+      );
+      expect(result).toEqual(mockSchedule);
+    });
+  });
+
+  describe('getStudentAcademicHistory', () => {
+    it('should return academic history', async () => {
+      const mockHistory = {
+        studentCode: 'STU001',
+        semesters: [],
+      };
+
+      (
+        studentScheduleService.getStudentAcademicHistory as jest.Mock
+      ).mockResolvedValue(mockHistory);
+
+      const result = await service.getStudentAcademicHistory('STU001');
+
+      expect(
+        studentScheduleService.getStudentAcademicHistory,
+      ).toHaveBeenCalledWith('STU001');
+      expect(result).toEqual(mockHistory);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should return fullName in response', async () => {
+      studentModel.findById.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockStudent),
+      });
+
+      const result = await service.findOne(mockStudentId);
+
+      expect(result).toHaveProperty('fullName');
+      expect(result.fullName).toBe('Juan Pérez');
+    });
+
+    it('should update only specified fields', async () => {
+      const updatedStudent = { ...mockStudent, currentSemester: 7 };
+      studentModel.findByIdAndUpdate.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(updatedStudent),
+      });
+
+      const result = await service.update(mockStudentId, { currentSemester: 7 });
+
+      expect(result.firstName).toBe('Juan'); // unchanged
+      expect(result.currentSemester).toBe(7); // changed
+    });
+  });
+});

--- a/src/test/validation-exception.filter.spec.ts
+++ b/src/test/validation-exception.filter.spec.ts
@@ -1,0 +1,438 @@
+import { ValidationExceptionFilter } from '../common/filters/validation-exception.filter';
+import { BadRequestException, ArgumentsHost } from '@nestjs/common';
+import { Response } from 'express';
+
+describe('ValidationExceptionFilter', () => {
+  let filter: ValidationExceptionFilter;
+  let mockResponse: Partial<Response>;
+  let mockRequest: any;
+  let mockArgumentsHost: ArgumentsHost;
+
+  beforeEach(() => {
+    filter = new ValidationExceptionFilter();
+
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    mockRequest = {
+      url: '/test-endpoint',
+    };
+
+    mockArgumentsHost = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getResponse: () => mockResponse,
+        getRequest: () => mockRequest,
+      }),
+    } as any;
+  });
+
+  describe('catch', () => {
+    it('should be defined', () => {
+      expect(filter).toBeDefined();
+    });
+
+    it('should handle validation errors with constraints', () => {
+      const validationErrors = [
+        {
+          property: 'email',
+          value: 'invalid-email',
+          constraints: {
+            isEmail: 'email must be an email',
+          },
+        },
+      ];
+
+      const exception = new BadRequestException({
+        message: validationErrors,
+      });
+
+      filter.catch(exception, mockArgumentsHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(422);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 422,
+          error: 'Validation Failed',
+          message: 'Los datos enviados contienen errores de validación',
+          path: '/test-endpoint',
+          errors: [
+            {
+              field: 'email',
+              message: 'email must be an email',
+              value: 'invalid-email',
+              constraint: 'isEmail',
+            },
+          ],
+        }),
+      );
+    });
+
+    it('should handle multiple validation errors', () => {
+      const validationErrors = [
+        {
+          property: 'email',
+          value: 'invalid',
+          constraints: {
+            isEmail: 'email must be an email',
+          },
+        },
+        {
+          property: 'password',
+          value: '123',
+          constraints: {
+            minLength: 'password must be at least 8 characters',
+            isStrongPassword: 'password is not strong enough',
+          },
+        },
+      ];
+
+      const exception = new BadRequestException({
+        message: validationErrors,
+      });
+
+      filter.catch(exception, mockArgumentsHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(422);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 422,
+          errors: expect.arrayContaining([
+            expect.objectContaining({ field: 'email' }),
+            expect.objectContaining({ field: 'password', constraint: 'minLength' }),
+            expect.objectContaining({ field: 'password', constraint: 'isStrongPassword' }),
+          ]),
+        }),
+      );
+    });
+
+    it('should handle nested validation errors (one level)', () => {
+      const validationErrors = [
+        {
+          property: 'address',
+          value: {},
+          children: [
+            {
+              property: 'street',
+              value: '',
+              constraints: {
+                isNotEmpty: 'street should not be empty',
+              },
+            },
+          ],
+        },
+      ];
+
+      const exception = new BadRequestException({
+        message: validationErrors,
+      });
+
+      filter.catch(exception, mockArgumentsHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(422);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 422,
+          errors: [
+            {
+              field: 'address.street',
+              message: 'street should not be empty',
+              value: '',
+              constraint: 'isNotEmpty',
+            },
+          ],
+        }),
+      );
+    });
+
+    it('should handle deeply nested validation errors (multiple levels)', () => {
+      const validationErrors = [
+        {
+          property: 'user',
+          value: {},
+          children: [
+            {
+              property: 'profile',
+              value: {},
+              children: [
+                {
+                  property: 'name',
+                  value: '',
+                  constraints: {
+                    isNotEmpty: 'name should not be empty',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const exception = new BadRequestException({
+        message: validationErrors,
+      });
+
+      filter.catch(exception, mockArgumentsHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(422);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          errors: [
+            {
+              field: 'user.profile.name',
+              message: 'name should not be empty',
+              value: '',
+              constraint: 'isNotEmpty',
+            },
+          ],
+        }),
+      );
+    });
+
+    it('should handle mixed direct and nested errors', () => {
+      const validationErrors = [
+        {
+          property: 'email',
+          value: 'invalid',
+          constraints: {
+            isEmail: 'email must be an email',
+          },
+        },
+        {
+          property: 'address',
+          value: {},
+          children: [
+            {
+              property: 'city',
+              value: '',
+              constraints: {
+                isNotEmpty: 'city should not be empty',
+              },
+            },
+          ],
+        },
+      ];
+
+      const exception = new BadRequestException({
+        message: validationErrors,
+      });
+
+      filter.catch(exception, mockArgumentsHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(422);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          errors: expect.arrayContaining([
+            expect.objectContaining({ field: 'email' }),
+            expect.objectContaining({ field: 'address.city' }),
+          ]),
+        }),
+      );
+    });
+
+    it('should handle errors with no constraints (edge case)', () => {
+      const validationErrors = [
+        {
+          property: 'field',
+          value: 'value',
+          // No constraints property
+        },
+      ];
+
+      const exception = new BadRequestException({
+        message: validationErrors,
+      });
+
+      filter.catch(exception, mockArgumentsHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(422);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          errors: [],
+        }),
+      );
+    });
+
+    it('should include timestamp in response', () => {
+      const validationErrors = [
+        {
+          property: 'field',
+          value: 'value',
+          constraints: {
+            test: 'test error',
+          },
+        },
+      ];
+
+      const exception = new BadRequestException({
+        message: validationErrors,
+      });
+
+      filter.catch(exception, mockArgumentsHost);
+
+      const responseCall = (mockResponse.json as jest.Mock).mock.calls[0][0];
+      expect(responseCall.timestamp).toBeDefined();
+      expect(typeof responseCall.timestamp).toBe('string');
+      expect(new Date(responseCall.timestamp).getTime()).not.toBeNaN();
+    });
+
+    it('should handle non-validation BadRequestException (string message)', () => {
+      const exception = new BadRequestException('Simple error message');
+
+      filter.catch(exception, mockArgumentsHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Simple error message',
+        }),
+      );
+    });
+
+    it('should handle non-validation BadRequestException (object without array message)', () => {
+      const exceptionResponse = {
+        statusCode: 400,
+        message: 'Not an array',
+        error: 'Bad Request',
+      };
+
+      const exception = new BadRequestException(exceptionResponse);
+
+      filter.catch(exception, mockArgumentsHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.json).toHaveBeenCalledWith(exceptionResponse);
+    });
+
+    it('should preserve request URL in response', () => {
+      mockRequest.url = '/api/v1/users/create';
+
+      const validationErrors = [
+        {
+          property: 'name',
+          value: '',
+          constraints: {
+            isNotEmpty: 'name should not be empty',
+          },
+        },
+      ];
+
+      const exception = new BadRequestException({
+        message: validationErrors,
+      });
+
+      filter.catch(exception, mockArgumentsHost);
+
+      const responseCall = (mockResponse.json as jest.Mock).mock.calls[0][0];
+      expect(responseCall.path).toBe('/api/v1/users/create');
+    });
+
+    it('should handle empty validation errors array', () => {
+      const exception = new BadRequestException({
+        message: [],
+      });
+
+      filter.catch(exception, mockArgumentsHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(422);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          errors: [],
+        }),
+      );
+    });
+
+    it('should handle error with multiple constraints on same field', () => {
+      const validationErrors = [
+        {
+          property: 'username',
+          value: 'ab',
+          constraints: {
+            minLength: 'username must be at least 3 characters',
+            maxLength: 'username must be at most 20 characters',
+            matches: 'username must contain only letters and numbers',
+          },
+        },
+      ];
+
+      const exception = new BadRequestException({
+        message: validationErrors,
+      });
+
+      filter.catch(exception, mockArgumentsHost);
+
+      const responseCall = (mockResponse.json as jest.Mock).mock.calls[0][0];
+      expect(responseCall.errors).toHaveLength(3);
+      expect(responseCall.errors.every((e: any) => e.field === 'username')).toBe(true);
+    });
+
+    it('should handle nested children without constraints', () => {
+      const validationErrors = [
+        {
+          property: 'parent',
+          value: {},
+          children: [
+            {
+              property: 'child',
+              value: 'value',
+              // No constraints
+            },
+          ],
+        },
+      ];
+
+      const exception = new BadRequestException({
+        message: validationErrors,
+      });
+
+      filter.catch(exception, mockArgumentsHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(422);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          errors: [],
+        }),
+      );
+    });
+
+    it('should format complex nested structure correctly', () => {
+      const validationErrors = [
+        {
+          property: 'order',
+          value: {},
+          children: [
+            {
+              property: 'items',
+              value: {},
+              children: [
+                {
+                  property: 'product',
+                  value: {},
+                  children: [
+                    {
+                      property: 'name',
+                      value: '',
+                      constraints: {
+                        isNotEmpty: 'product name is required',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const exception = new BadRequestException({
+        message: validationErrors,
+      });
+
+      filter.catch(exception, mockArgumentsHost);
+
+      const responseCall = (mockResponse.json as jest.Mock).mock.calls[0][0];
+      expect(responseCall.errors[0].field).toBe('order.items.product.name');
+    });
+  });
+});

--- a/src/waitlists/waitlists.controller.ts
+++ b/src/waitlists/waitlists.controller.ts
@@ -7,6 +7,13 @@ import {
   Param,
   Delete,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 import { WaitlistsService } from './services/waitlists.service';
 import { CreateWaitlistDto } from './dto/create-waitlist.dto';
 import { UpdateWaitlistDto } from './dto/update-waitlist.dto';
@@ -16,9 +23,9 @@ import { UpdateWaitlistDto } from './dto/update-waitlist.dto';
  *
  * ! Controller completamente sin implementar - Requiere implementacion completa del servicio
  * ? Este controlador maneja las listas de espera para grupos llenos
- * TODO: Implementar Swagger documentation completa
  * TODO: Agregar validaciones de autenticacion y autorizacion
  */
+@ApiTags('Waitlists')
 @Controller('waitlists')
 export class WaitlistsController {
   constructor(private readonly waitlistsService: WaitlistsService) {}
@@ -30,6 +37,17 @@ export class WaitlistsController {
    * TODO: Agregar validacion de estudiante duplicado en waitlist
    */
   @Post()
+  @ApiOperation({
+    summary: 'Add student to waitlist',
+    description: 'Creates a new waitlist entry when a course group is full',
+  })
+  @ApiBody({ type: CreateWaitlistDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Student successfully added to waitlist',
+  })
+  @ApiResponse({ status: 400, description: 'Invalid waitlist data' })
+  @ApiResponse({ status: 409, description: 'Student already in waitlist' })
   create(@Body() createWaitlistDto: CreateWaitlistDto) {
     return this.waitlistsService.create(createWaitlistDto);
   }
@@ -41,6 +59,14 @@ export class WaitlistsController {
    * TODO: Agregar filtros por estado de waitlist
    */
   @Get()
+  @ApiOperation({
+    summary: 'Get all waitlist entries',
+    description: 'Retrieves a list of all waitlist entries with position information',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of waitlist entries retrieved successfully',
+  })
   findAll() {
     return this.waitlistsService.findAll();
   }
@@ -52,6 +78,16 @@ export class WaitlistsController {
    * TODO: Agregar validacion de existencia del registro
    */
   @Get(':id')
+  @ApiOperation({
+    summary: 'Get waitlist entry by ID',
+    description: 'Retrieves a specific waitlist entry with position information',
+  })
+  @ApiParam({ name: 'id', description: 'Waitlist entry ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Waitlist entry found',
+  })
+  @ApiResponse({ status: 404, description: 'Waitlist entry not found' })
   findOne(@Param('id') id: string) {
     return this.waitlistsService.findOne(+id);
   }
@@ -63,6 +99,18 @@ export class WaitlistsController {
    * TODO: Implementar logica de procesamiento automatico
    */
   @Patch(':id')
+  @ApiOperation({
+    summary: 'Update waitlist entry',
+    description: 'Updates waitlist entry status. May trigger automatic enrollment',
+  })
+  @ApiParam({ name: 'id', description: 'Waitlist entry ID' })
+  @ApiBody({ type: UpdateWaitlistDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Waitlist entry successfully updated',
+  })
+  @ApiResponse({ status: 404, description: 'Waitlist entry not found' })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
   update(
     @Param('id') id: string,
     @Body() updateWaitlistDto: UpdateWaitlistDto,
@@ -77,6 +125,16 @@ export class WaitlistsController {
    * TODO: Notificar a otros estudiantes sobre cambio de posicion
    */
   @Delete(':id')
+  @ApiOperation({
+    summary: 'Remove from waitlist',
+    description: 'Removes a student from the waitlist and reorders remaining positions',
+  })
+  @ApiParam({ name: 'id', description: 'Waitlist entry ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Student successfully removed from waitlist',
+  })
+  @ApiResponse({ status: 404, description: 'Waitlist entry not found' })
   remove(@Param('id') id: string) {
     return this.waitlistsService.remove(+id);
   }


### PR DESCRIPTION
This pull request adds comprehensive Swagger documentation to all main REST API controllers in the codebase, improving API discoverability, client usability, and maintainability. Each controller now includes detailed endpoint descriptions, parameter documentation, response status codes, and grouping with tags. The changes also introduce authentication documentation for the roles controller.

**Swagger Documentation Enhancements**

* All controllers (`change-windows`, `enrollments`, `group-schedules`, `programs`, `reports`, and `roles`) now import Swagger decorators and use them to annotate endpoints with summaries, descriptions, parameters, request bodies, and response codes. [[1]](diffhunk://#diff-34d38f3515cb2424f40ad5360e95d72baed4f2a73c2d491a4538f23a36bce4eeR10-R81) [[2]](diffhunk://#diff-198e833e464cacf25179682cd7351d3f89a2ceb137f8bf78ecd53a7e6fa01407R10-R54) [[3]](diffhunk://#diff-666ca0708ba6d80c0aaa98a8512465b84ece88568978b43d3aa3975702973602R10-R83) [[4]](diffhunk://#diff-1a4c0c71939cd5961befa4ba0f95cf0c9d4166a3afa1abc1243c647a44a1d517R10-R16) [[5]](diffhunk://#diff-4c850a2ce3073deeea1487342b8cd15c5c931d1e7b5c7c1df2bcd95c0521127bR10-R96) [[6]](diffhunk://#diff-c1626adb3e963d51a13077a3b39947102601a4b512637761b37db7ea64f9b6a3R10-R17)

**Endpoint Documentation Improvements**

* Each CRUD endpoint in all controllers is now annotated with `@ApiOperation`, `@ApiResponse`, and where applicable, `@ApiParam` and `@ApiBody`, providing clear documentation for API consumers. [[1]](diffhunk://#diff-34d38f3515cb2424f40ad5360e95d72baed4f2a73c2d491a4538f23a36bce4eeR90-R99) [[2]](diffhunk://#diff-198e833e464cacf25179682cd7351d3f89a2ceb137f8bf78ecd53a7e6fa01407R63-R117) [[3]](diffhunk://#diff-198e833e464cacf25179682cd7351d3f89a2ceb137f8bf78ecd53a7e6fa01407R126-R135) [[4]](diffhunk://#diff-666ca0708ba6d80c0aaa98a8512465b84ece88568978b43d3aa3975702973602R92-R101) [[5]](diffhunk://#diff-1a4c0c71939cd5961befa4ba0f95cf0c9d4166a3afa1abc1243c647a44a1d517R41-R51) [[6]](diffhunk://#diff-1a4c0c71939cd5961befa4ba0f95cf0c9d4166a3afa1abc1243c647a44a1d517R63-R70) [[7]](diffhunk://#diff-1a4c0c71939cd5961befa4ba0f95cf0c9d4166a3afa1abc1243c647a44a1d517R82-R91) [[8]](diffhunk://#diff-1a4c0c71939cd5961befa4ba0f95cf0c9d4166a3afa1abc1243c647a44a1d517R103-R114) [[9]](diffhunk://#diff-1a4c0c71939cd5961befa4ba0f95cf0c9d4166a3afa1abc1243c647a44a1d517R127-R140) [[10]](diffhunk://#diff-4c850a2ce3073deeea1487342b8cd15c5c931d1e7b5c7c1df2bcd95c0521127bR10-R96)

**Tagging and Grouping**

* Each controller is now grouped under a logical tag using `@ApiTags`, making the API documentation easier to navigate (e.g., 'Enrollments', 'Academic Programs', 'Group Schedules', etc.). [[1]](diffhunk://#diff-34d38f3515cb2424f40ad5360e95d72baed4f2a73c2d491a4538f23a36bce4eeR10-R81) [[2]](diffhunk://#diff-198e833e464cacf25179682cd7351d3f89a2ceb137f8bf78ecd53a7e6fa01407R10-R54) [[3]](diffhunk://#diff-666ca0708ba6d80c0aaa98a8512465b84ece88568978b43d3aa3975702973602R10-R83) [[4]](diffhunk://#diff-1a4c0c71939cd5961befa4ba0f95cf0c9d4166a3afa1abc1243c647a44a1d517L19-R29) [[5]](diffhunk://#diff-4c850a2ce3073deeea1487342b8cd15c5c931d1e7b5c7c1df2bcd95c0521127bR10-R96) [[6]](diffhunk://#diff-c1626adb3e963d51a13077a3b39947102601a4b512637761b37db7ea64f9b6a3L20-R31)

**Authentication Documentation**

* The `roles` controller now includes `@ApiBearerAuth()` to indicate endpoints require authentication, further clarifying API security requirements.

**Removal of Outdated Documentation TODOs**

* Old TODO comments about Swagger documentation in controllers are removed or updated, reflecting the completion of documentation tasks. [[1]](diffhunk://#diff-1a4c0c71939cd5961befa4ba0f95cf0c9d4166a3afa1abc1243c647a44a1d517L19-R29) [[2]](diffhunk://#diff-c1626adb3e963d51a13077a3b39947102601a4b512637761b37db7ea64f9b6a3L20-R31)